### PR TITLE
A few fixes to the "Contact" section

### DIFF
--- a/app/views/contact/finished.html
+++ b/app/views/contact/finished.html
@@ -5,19 +5,19 @@
 {% endblock %}
 
 {% block content %}
-
 <main id="content" role="main">
 
-<h1 class="heading-large">
-  Your application is now complete
-</h1>
+  <h1 class="heading-large">
+    Your application is now complete
+  </h1>
 
-<p>
-  You should now receive details of what to do next by the contact method you've chosen.
-</p>
+  <p>
+    You should now receive details of what to do next by the contact method you've chosen.
+  </p>
 
-<p>
-  <a href="#">Contact the council</a> if you haven't received details of what to do next.
-</p>
+  <p>
+    <a href="#">Contact the council</a> if you haven't received details of what to do next.
+  </p>
 
+</main>
 {% endblock %}

--- a/app/views/contact/index.html
+++ b/app/views/contact/index.html
@@ -8,74 +8,81 @@
 
 <main id="content" role="main">
 
-<h1 class="heading-medium">
-  How would you like to receive your confirmation of payment and reminder to update?
-</h1>
+  <h1 class="heading-medium">
+    How would you like to receive your confirmation of payment and reminder to update?
+  </h1>
 
-<form>
-  <div class="form-group">
-    <fieldset>
+  <form action="contact/finished">
+    <div class="form-group">
+      <fieldset>
 
-      <legend class="visually-hidden">How would you like to receive your receipt?</legend>
+        <legend class="visually-hidden">
+          How would you like to receive your confirmation of payment and reminder to update?
+        </legend>
 
-      <label class="block-label selection-button-radio" data-target="contact-by-email" for="example-contact-by-email">
-        <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
-        Email
-      </label>
-      <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
-        <label class="form-label" for="contact-email">Email address</label>
-        <input class="form-control" name="contact-email" type="text" id="contact-email">
-      </div>
+        <label class="block-label selection-button-radio" data-target="contact-by-email" for="example-contact-by-email">
+          <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
+          Email
+        </label>
+        <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
+          <label class="form-label" for="contact-email">Email address</label>
+          <input class="form-control" name="contact-email" type="text" id="contact-email">
+        </div>
 
-      <label class="block-label selection-button-radio" data-target="contact-by-text" for="example-contact-by-text">
-        <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
-        Text message
-      </label>
-      <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
-        <label class="form-label" for="contact-text-message">Mobile phone number</label>
-        <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
-      </div>
+        <label class="block-label selection-button-radio" data-target="contact-by-text" for="example-contact-by-text">
+          <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
+          Text message
+        </label>
+        <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
+          <label class="form-label" for="contact-text-message">Mobile phone number</label>
+          <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
+        </div>
 
-      <label class="block-label selection-button-radio" for="billing-address">
-        <input id="billing-address" type="radio" name="radio-contact-group" value="No">
-        Letter (sent to billing address)
-      </label>
+        <label class="block-label selection-button-radio" for="billing-address">
+          <input id="billing-address" type="radio" name="radio-contact-group" value="No">
+          Letter (sent to billing address)
+        </label>
 
-      <label class="block-label selection-button-radio" data-target="contact-by-letter" for="example-contact-by-letter">
-        <input id="example-contact-by-letter" type="radio" name="radio-contact-group" value="No">
-        Letter (sent to a different address)
-      </label>
-      <div class="panel panel-border-narrow js-hidden" id="contact-by-letter">
-        <label class="form-label" for="contact-letter-message">Address</label>
+        <label class="block-label selection-button-radio" data-target="contact-by-letter" for="example-contact-by-letter">
+          <input id="example-contact-by-letter" type="radio" name="radio-contact-group" value="No">
+          Letter (sent to a different address)
+        </label>
+        <div class="panel panel-border-narrow js-hidden" id="contact-by-letter">
           <fieldset>
-        <div class="form-group">
-          <label class="form-label-bold" for="building-and-street">
-            Building name and/or number and street
-            </label>
-            <input class="form-control" id="building-and-street" name="building-and-street" type="text">
-            <input class="form-control" id="building-and-street" name="building-and-street" type="text">
+            <legend>
+              <span class="form-label">Address</span>
+            </legend>
+            <div class="form-group">
+              <label class="form-label-bold" for="building-and-street">
+                Building name and/or number and street
+              </label>
+              <input class="form-control" id="building-and-street" name="building-and-street" type="text">
+              <label class="visually-hidden" for="building-and-street-2">
+                Address line 2 (optional)
+              </label>
+              <input class="form-control" id="building-and-street-2" name="building-and-street-2" type="text">
+            </div>
+            <div class="form-group">
+              <label class="form-label-bold" for="town-or-city">
+                Town or city
+              </label>
+              <input class="form-control medium-width" id="town-or-city" name="town-or-city" type="text">
+            </div>
+            <div class="form-group">
+              <label class="form-label-bold" for="postcode">
+                Postcode
+              </label>
+              <input class="form-control" id="postcode" name="postcode" type="text">
+            </div>
+          </fieldset>
         </div>
-        <div class="form-group">
-          <label class="form-label-bold" for="town-or-city">
-            Town or city
-            </label>
-            <input class="form-control medium-width" id="town-or-city" name="town-or-city" type="text">
-        </div>
-        <div class="form-group">
-          <label class="form-label-bold" for="postcode">
-            Postcode
-            </label>
-            <input class="form-control" id="postcode" name="postcode" type="text">
-        </div>
-      </div>
 
-    </fieldset>
-  </div>
+      </fieldset>
+    </div>
+    <div class="form-group">
+      <input type="submit" class="button" name="Continue">
+    </div>
+  </form>
 
-  <div class="form-group">
-    <!-- <input type="submit" class="button" name="Continue"</input> -->
-    <a href="contact/finished" class="button">Continue</a>
-  </div>
-</form>
-
+</main>
 {% endblock %}

--- a/lib/argleton_template.html
+++ b/lib/argleton_template.html
@@ -54,7 +54,7 @@
     <!-- argleton header -->
     <header>
       <div class="container">
-        <img src="{{ asset_path }}images/tree.svg" />
+        <img src="{{ asset_path }}images/tree.svg" alt="Argleton logo">
         <span class="argleton-name">Argleton </span><span class="argleton-name-extra">County Council</span>
         <div class="contact-link">
           <a href="#">Contact</a>


### PR DESCRIPTION
Ensure this page validates as valid HTML - remove duplicate IDs, add a missing 'alt' attribute to Appleton logo, add missing closing `</main>` element.

Update visually-hidden legend text to match the page title.

Fix indentation.