### PR TITLE
Fix the HTML on the non-verify start pages

### DIFF
--- a/app/views/service-patterns/concessionary-travel/example-service/start-non-verify.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-non-verify.html
@@ -8,13 +8,10 @@
 
 <main id="content" role="main">
 
-  <h1 class="heading-xlarge">Apply for a resident's parking permit in Argleton</h1>
+  <h1 class="heading-xlarge">Apply for an older person's bus pass in Argleton</h1>
 
   <p>
-    To park in Argleton City centre, you'll need a resident's parking permit.
-  </p>
-  <p>
-    Parking permits allow you to park anywhere within the <a href="https://www.theguardian.com/technology/2009/nov/03/google">boundaries of the city</a>.
+    In England you can get a bus pass for free local travel when you reach the female State Pension age, whether you’re a man or a woman.
   </p>
 
 

--- a/app/views/service-patterns/concessionary-travel/example-service/start-non-verify.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-non-verify.html
@@ -16,27 +16,17 @@
   <p>
     Parking permits allow you to park anywhere within the <a href="https://www.theguardian.com/technology/2009/nov/03/google">boundaries of the city</a>.
   </p>
-     
-<h2 class="heading-medium">About this service</h2>
-    <ul class="list list-bullet">
-      <li>
-        Each household is allowed up to four permits
-      </li>
-       <li>
-      Prices per year are as follows: <br>
-      £51 for the first vehicle in the household <br>
-      £81 for the second vehicle in the household <br>
-      £153 for the third vehicle in the household <br>
-      £153 for the fourth vehicle in the household <br>
-      </li>
-      
-<h2 class= "heading-medium">To apply online you will need to provide:</h2>
-    <ul class="list list-bullet">
-<li>Proof of address, such as a council tax bill or a recent utility bill or a tennancy agreement or a mortgage statement</li>
-<li>Proof of age, such as a birth certificate, a passport or a driving license<li>
-</main>
+
+
+  <h2 class= "heading-medium">To apply online you will need to provide:</h2>
+
+  <ul class="list list-bullet">
+    <li>Proof of address, such as a council tax bill or a recent utility bill or a tennancy agreement or a mortgage statement</li>
+    <li>Proof of age, such as a birth certificate, a passport or a driving license</li>
+  </ul>
 
   <a class="button button-start" href="add-dob" role="button">Apply online now</a>
 
+</main>
 
 {% endblock %}

--- a/app/views/service-patterns/concessionary-travel/example-service/start-page.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-page.html
@@ -14,7 +14,8 @@
     In England you can get a bus pass for free local travel when you reach the female State Pension age, whether you’re a man or a woman.
   </p>
   <p>
-    The pass is valid on any local bus in England at any time on a Saturday, Sunday or bank holiday, and from 9.30am to 11pm on any other day. 
+    The pass is valid on any local bus in England at any time on a Saturday, Sunday or bank holiday, and from 9.30am to 11pm on any other day.
+  </p>
   <p>
     If you live in <a href="https://www.theguardian.com/technology/2009/nov/03/google">Argleton</a>, you should apply through this service. The pass will be valid on all bus services in England.
   </p>

--- a/app/views/service-patterns/parking-permit/example-service/start-non-verify.html
+++ b/app/views/service-patterns/parking-permit/example-service/start-non-verify.html
@@ -16,23 +16,29 @@
   <p>
     Parking permits allow you to park anywhere within the <a href="https://www.theguardian.com/technology/2009/nov/03/google">boundaries of the city</a>.
   </p>
-     
-<h2 class="heading-medium">About this service</h2>
-    <ul class="list list-bullet">
-      <li>
-        Each household is allowed up to four permits
-      </li>
-       <li>
-      Prices per year are as follows: <br>
-      £51 for the first vehicle in the household <br>
-      £81 for the second vehicle in the household <br>
-      £153 for the third vehicle in the household <br>
-      £153 for the fourth vehicle in the household <br>
-      </li>
-      
-<h2 class= "heading-medium">To apply online you will need to provide:</h2>
-    <ul class="list list-bullet">
-<li>Proof of address, such as a council tax bill or a recent utility bill or a tennancy agreement or a mortgage statement</li>
+
+  <h2 class="heading-medium">About this service</h2>
+
+  <ul class="list list-bullet">
+    <li>
+      Each household is allowed up to four permits
+    </li>
+    <li>
+      Prices per year are as follows:
+      <ul class="list list-circle">
+        <li>£51 for the first vehicle in the household</li>
+        <li>£81 for the second vehicle in the household</li>
+        <li>£153 for the third vehicle in the household</li>
+        <li>£153 for the fourth vehicle in the household</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2 class= "heading-medium">To apply online you will need to provide:</h2>
+
+  <ul class="list list-bullet">
+    <li>Proof of address, such as a council tax bill or a recent utility bill or a tennancy agreement or a mortgage statement</li>
+  </ul>
 
   <a class="button button-start" href="add-address" role="button">Apply online now</a>
 


### PR DESCRIPTION
Fixes #127, as well as a few missing closing HTML tags and some PP content on the ConTravel page.

Before
<img width="907" alt="screen shot 2017-02-06 at 15 48 05" src="https://cloud.githubusercontent.com/assets/4106955/22654338/5ff05984-ec84-11e6-96c7-0df4f6e2a6c5.png">
![screen shot 2017-02-06 at 15 48 54](https://cloud.githubusercontent.com/assets/4106955/22654349/6a6f41e0-ec84-11e6-9636-554074aa004c.png)

After
<img width="904" alt="screen shot 2017-02-06 at 15 52 51" src="https://cloud.githubusercontent.com/assets/4106955/22654365/74fc25e2-ec84-11e6-869c-9d69ad445535.png">
![screen shot 2017-02-06 at 15 52 40](https://cloud.githubusercontent.com/assets/4106955/22654366/7507b736-ec84-11e6-939e-f7f6abca0a1c.png)
