### PR TITLE
Change format of index pages to match service manual patterns

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -86,3 +86,8 @@ h1 span.strapline {
     text-decoration: none;
     letter-spacing: 0.022em;
 }
+
+.page-contents__list .active {
+    letter-spacing: 0;
+    font-weight: bold;
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -43,3 +43,24 @@ h1 span.strapline {
     line-height: 1.1111111111;
   }
 }
+
+.metadata {
+  font-weight: 400;
+  text-transform: none;
+  font-size: 12px;
+  line-height: 1.25;
+  margin-bottom: 2em;
+  @media (min-width: 641px) {
+    font-size: 14px;
+    line-height: 1.42857;
+  }
+  dt {
+    float: left;
+    clear: left;
+    width: auto;
+    min-width: 120px;
+    @media (min-width: 641px) {
+      padding-right: 10px;
+    }
+  }  
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -45,8 +45,6 @@ h1 span.strapline {
 }
 
 .metadata {
-  font-weight: 400;
-  text-transform: none;
   font-size: 12px;
   line-height: 1.25;
   margin-bottom: 2em;
@@ -62,5 +60,29 @@ h1 span.strapline {
     @media (min-width: 641px) {
       padding-right: 10px;
     }
-  }  
+  }
+}
+
+.page-contents__list li {
+  font-size: 14px;
+  line-height: 1.14286;
+  list-style-type: none;
+  margin-bottom: 5px;
+  margin-left: 15px;
+  padding-right: 15px;
+  &:before {
+    content: "–";
+    float: left;
+    display: block;
+    width: 15px;
+    margin-left: -15px;
+  }
+  @media (min-width: 641px){
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+.page-contents__list a {
+    text-decoration: none;
+    letter-spacing: 0.022em;
 }

--- a/app/views/includes/index_metadata.html
+++ b/app/views/includes/index_metadata.html
@@ -1,0 +1,18 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <div class="metadata">
+      <dl>
+          <dt>Published by:</dt>
+            <dd>
+              <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+            </dd>
+        <dt>Last updated:</dt>
+        <dd>
+          1 day ago
+        </dd>
+      </dl>
+    </div>
+
+  </div>
+</div>

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -5,3 +5,4 @@
 <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
 <script src="/public/javascripts/govuk/show-hide-content.js"></script>
 <script src="/public/javascripts/application.js"></script>
+<script src="https://assets.publishing.service.gov.uk/service-manual-frontend/application-6e1076c8610026f4245c8eb8f5976a50b4ed2f2ef82f9fbb5f1811913e1561d4.js"></script>

--- a/app/views/includes/toolkit_breadcrumbs.html
+++ b/app/views/includes/toolkit_breadcrumbs.html
@@ -1,0 +1,13 @@
+<div class="breadcrumbs" data-module="track-click">
+  <ol>
+    <li>
+        <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/service-manual" data-track-dimension="Service manual" data-track-dimension-index="29" href="http://gov.uk/service-toolkit">Service toolkit</a>
+    </li>
+    <li>
+        <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="/service-manual/design" data-track-dimension="Design" data-track-dimension-index="29" href="/">Local government service patterns</a>
+    </li>
+    <li>
+        {{ pageTitle }}
+    </li>
+  </ol>
+</div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,12 +7,11 @@
 {% block content %}
 
 <main id="content" role="main">
-  {% include "includes/phase_banner_alpha.html" %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
       <h1 class="heading-xlarge">
-        Service patterns for local government services
+        Local government service patterns
       </h1>
 
       <p>

--- a/app/views/service-patterns/concessionary-travel/index.html
+++ b/app/views/service-patterns/concessionary-travel/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% set pageTitle = "Apply online for a older person's concessionary travel pass" %}
+{% set pageTitle = "Apply for an older person's concessionary travel pass" %}
 {% block page_title %}
   {{
     pageTitle

--- a/app/views/service-patterns/concessionary-travel/index.html
+++ b/app/views/service-patterns/concessionary-travel/index.html
@@ -19,6 +19,8 @@
         {{ pageTitle }}
       </h1>
 
+      {% include "includes/index_metadata.html" %}
+
       <p>
          This page is for people who work in local authorities. It outlines a common pattern used for delivering older person's concessionary travel services effectively. <a href="/">Read more about service patterns.</a>
       </p>

--- a/app/views/service-patterns/concessionary-travel/index.html
+++ b/app/views/service-patterns/concessionary-travel/index.html
@@ -11,16 +11,28 @@
 <main id="content" role="main">
   {% include "includes/phase_banner_alpha.html" %}
   {% include "includes/toolkit_breadcrumbs.html" %}
-  <div class="grid-row">
+
+  <h1 class="heading-xlarge">
+    <span class="strapline">Service pattern for</span>
+    {{ pageTitle }}
+  </h1>
+
+  {% include "includes/index_metadata.html" %}
+
+  <div class="grid-row" data-module="highlight-active-section-heading">
+    <div class="column-third">
+      <!--  Page contents -->
+      <div class="page-contents js-page-contents js-stick-at-top-when-scrolling js-sticky-resize" style="width: 212px;">
+        <h2 class="heading-small page-contents__title">Page contents:</h2>
+        <ul class="page-contents__list">
+            <li><a href="#user-need">What is the user need?</a></li>
+            <li><a href="#council-need">What do councils need?</a></li>
+            <li><a href="#user-journey">What is the user journey?</a></li>
+        </ul>
+      </div>
+
+    </div>
     <div class="column-two-thirds">
-
-      <h1 class="heading-xlarge">
-        <span class="strapline">Service pattern for</span>
-        {{ pageTitle }}
-      </h1>
-
-      {% include "includes/index_metadata.html" %}
-
       <p>
          This page is for people who work in local authorities. It outlines a common pattern used for delivering older person's concessionary travel services effectively. <a href="/">Read more about service patterns.</a>
       </p>
@@ -28,18 +40,18 @@
          This pattern is specific to England. Concessionary travel passes work differently in <a href="http://www.transport.gov.scot/public-transport/concessionary-travel-people-aged-60-or-disability">Scotland</a>, <a href="http://gov.wales/topics/transport/public/concessionary/?lang=en">Wales</a> and <a href="https://www.nidirect.gov.uk/articles/free-and-concessionary-bus-and-rail-travel
 ">Northern Ireland</a>.
       </p>
-<p>
+      <p>
         This is made possible through the English National Concessionary Travel Scheme. The Department of Transport has <a href="https://www.gov.uk/government/publications/guidance-for-travel-concession-authorities-on-the-england-national-concessionary-travel-scheme">published guidance for councils</a> about this scheme.
       </p>
 
-      <h2 class="heading-medium">What is the user need?</h2>
+      <h2 class="heading-medium" id="user-need">What is the user need?</h2>
       <p>
        As someone who is eligible to travel for free <br>
 I need to apply for a concessionary travel permit <br>
 So that I am able to travel for free
       </p>
 
-      <h2 class="heading-medium">What do councils need from users to deliver the service?</h2>
+      <h2 class="heading-medium" id="council-need">What do councils need from users to deliver the service?</h2>
       <ul class="list list-bullet">
         <li>
           proof that the user lives in the area
@@ -52,7 +64,7 @@ So that I am able to travel for free
         </li>
       </ul>
 
-      <h2 class="heading-medium">What is the user journey?</h2>
+      <h2 class="heading-medium" id="user-journey">What is the user journey?</h2>
       <p>
         At a high level, these are the steps users should go through.
       </p>

--- a/app/views/service-patterns/concessionary-travel/index.html
+++ b/app/views/service-patterns/concessionary-travel/index.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 <main id="content" role="main">
-  {% include "includes/phase_banner_pattern.html" %}
+  {% include "includes/phase_banner_alpha.html" %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
@@ -33,7 +33,7 @@
 I need to apply for a concessionary travel permit <br>
 So that I am able to travel for free
       </p>
-      
+
       <h2 class="heading-medium">What do councils need from users to deliver the service?</h2>
       <ul class="list list-bullet">
         <li>

--- a/app/views/service-patterns/concessionary-travel/index.html
+++ b/app/views/service-patterns/concessionary-travel/index.html
@@ -1,19 +1,22 @@
 {% extends "layout.html" %}
-
+{% set pageTitle = "Apply online for a older person's concessionary travel pass" %}
 {% block page_title %}
-  Service pattern for Apply online for a older person's concessionary travel pass
+  {{
+    pageTitle
+  }}
 {% endblock %}
 
 {% block content %}
 
 <main id="content" role="main">
   {% include "includes/phase_banner_alpha.html" %}
+  {% include "includes/toolkit_breadcrumbs.html" %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
       <h1 class="heading-xlarge">
         <span class="strapline">Service pattern for</span>
-        Apply online for a older person's concessionary travel pass
+        {{ pageTitle }}
       </h1>
 
       <p>

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 <main id="content" role="main">
-  {% include "includes/phase_banner_pattern.html" %}
+  {% include "includes/phase_banner_alpha.html" %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
@@ -162,7 +162,7 @@
 
             <h4 class="heading-small">7c. Is the user eligible for multiple permits?</h4>
       <p>
-        If the user is elibible for multiple permits, for example visitors permits, the council should ask which type of permit the user would like to apply for. 
+        If the user is elibible for multiple permits, for example visitors permits, the council should ask which type of permit the user would like to apply for.
       </p>
       <p>
         <a href="parking-permit/example-service/eligible-for-many">See the example page asks the user to select which permit they wish to apply for.</a>
@@ -174,7 +174,7 @@
       </p>
       <p>
       If the price of the permit varies depending on the vehicle type, emissions, make or any other condition, the council should present information or a tool that allows correct calculation of the permit price
-      </p>      
+      </p>
       <p>
         <a href="parking-permit/example-service/enter-reg">See the example page of asking for a registration number</a>
       </p>

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -19,6 +19,8 @@
         {{ pageTitle }}
       </h1>
 
+      {% include "includes/index_metadata.html" %}
+
       <p>
          This page is for people who work in local authorities. It outlines a common pattern used for delivering resident's parking permits services effectively. <a href="/">Read more about service patterns.</a>
       </p>

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -1,19 +1,22 @@
 {% extends "layout.html" %}
-
+{% set pageTitle = "Apply for a resident's parking permit in Argleton" %}
 {% block page_title %}
-  Service pattern for Apply for a resident's parking permit in Argleton
+  {{
+    pageTitle
+  }}
 {% endblock %}
 
 {% block content %}
 
 <main id="content" role="main">
   {% include "includes/phase_banner_alpha.html" %}
+  {% include "includes/toolkit_breadcrumbs.html" %}
   <div class="grid-row">
     <div class="column-two-thirds">
 
       <h1 class="heading-xlarge">
         <span class="strapline">Service pattern for</span>
-        Apply online for a resident's parking permit
+        {{ pageTitle }}
       </h1>
 
       <p>

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% set pageTitle = "Apply for a resident's parking permit in Argleton" %}
+{% set pageTitle = "Apply for a resident's parking permit" %}
 {% block page_title %}
   {{
     pageTitle

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -11,27 +11,40 @@
 <main id="content" role="main">
   {% include "includes/phase_banner_alpha.html" %}
   {% include "includes/toolkit_breadcrumbs.html" %}
-  <div class="grid-row">
+
+  <h1 class="heading-xlarge">
+    <span class="strapline">Service pattern for</span>
+    {{ pageTitle }}
+  </h1>
+
+  {% include "includes/index_metadata.html" %}
+
+  <div class="grid-row" data-module="highlight-active-section-heading">
+    <div class="column-third">
+
+      <!--  Page contents -->
+      <div class="page-contents js-page-contents js-stick-at-top-when-scrolling js-sticky-resize" style="width: 212px;">
+        <h2 class="heading-small page-contents__title">Page contents:</h2>
+        <ul class="page-contents__list">
+            <li><a href="#user-need">What is the user need?</a></li>
+            <li><a href="#council-need">What do councils need?</a></li>
+            <li><a href="#user-journey">What is the user journey?</a></li>
+        </ul>
+      </div>
+
+    </div>
     <div class="column-two-thirds">
-
-      <h1 class="heading-xlarge">
-        <span class="strapline">Service pattern for</span>
-        {{ pageTitle }}
-      </h1>
-
-      {% include "includes/index_metadata.html" %}
-
       <p>
          This page is for people who work in local authorities. It outlines a common pattern used for delivering resident's parking permits services effectively. <a href="/">Read more about service patterns.</a>
       </p>
 
-      <h2 class="heading-medium">What is the user need?</h2>
+      <h2 class="heading-medium" id="user-need">What is the user need?</h2>
       <p>
         Residents need a place to park their car near their home. Parking permit services make sure that parking spaces are only occupied by residents by making it illegal to park in a given area without a permit.
       </p>
       <p>We recommend that local authorities provide the parking permit service using a user centric approach.</p>
 
-      <h2 class="heading-medium">What do councils need from users to deliver the service?</h2>
+      <h2 class="heading-medium" id="council-need">What do councils need from users to deliver the service?</h2>
       <p>Depending on local authority needs, the user may be asked to provide a combination of:</p>
       <ul class="list list-bullet">
         <li>
@@ -45,7 +58,7 @@
         </li>
       </ul>
 
-      <h2 class="heading-medium">What is the user journey?</h2>
+      <h2 class="heading-medium" id="user-journey">What is the user journey?</h2>
       <p>
         At a high level, these are the steps users should need to go through.
       </p>
@@ -140,7 +153,7 @@
         If the permit is digital and councils want extra confidence of eligibility, they can issue a temporary permit for a shorter time period, for example 3 months. After this time, the user's identity provider should have the new address and the user can reapply.
       </p>
 
-<h3 class="heading-small">6. If a user fails to Verify</h3>
+  <h3 class="heading-small">6. If a user fails to Verify</h3>
 
         <p>If a user fails to verify the council should provide other ways for the use to apply. These other ways could include:</p>
         <ul class="list list-bullet">
@@ -256,9 +269,9 @@
       <p>
         <a href="#">See the example renewal notification.</a> (page in progress)
       </p>
-
     </div>
   </div>
+
 </main>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #121. Should work on both services, but screenshots below just show parking permits.

Before
<img width="1327" alt="screen shot 2017-02-08 at 12 32 33" src="https://cloud.githubusercontent.com/assets/4106955/22737358/b4051920-edfa-11e6-9f00-e31e97b61ee8.png">

After
<img width="1331" alt="screen shot 2017-02-08 at 12 33 52" src="https://cloud.githubusercontent.com/assets/4106955/22737413/e0f0919e-edfa-11e6-8e5a-4d8eef79fe0b.png">

The menu sticks to the side, the links link to the sections, and when you click or scroll an item it will go bold.
<img width="1341" alt="screen shot 2017-02-08 at 12 35 12" src="https://cloud.githubusercontent.com/assets/4106955/22737456/108d1044-edfb-11e6-8a97-7bcb305d17ff.png">
