### PR TITLE
Swapping around date of birth, address, and existing permits checks

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -51,14 +51,14 @@ router.get('/service-patterns/parking-permit/example-service/eligible', function
   }
 })
 
-router.get('/service-patterns/concessionary-travel/example-service/confirm-dob', function (req, res) {
+router.get('/service-patterns/concessionary-travel/example-service/confirm-address', function (req, res) {
   // get the answer from the query string (eg. ?over18=false)
   var answer = req.query.answer
 
   if (answer === 'No') {
-    res.redirect('incorrect-address')
+    res.redirect('incorrect-dob')
   } else {
-    res.render('service-patterns/concessionary-travel/example-service/confirm-dob')
+    res.render('service-patterns/concessionary-travel/example-service/confirm-address')
   }
 })
 
@@ -67,7 +67,7 @@ router.get('/service-patterns/concessionary-travel/example-service/eligible', fu
   var answer = req.query.answer
 
   if (answer === 'No') {
-    res.redirect('incorrect-dob')
+    res.redirect('incorrect-address')
   } else {
     res.render('service-patterns/concessionary-travel/example-service/eligible')
   }

--- a/app/views/service-patterns/concessionary-travel/example-service/confirm-address.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/confirm-address.html
@@ -27,7 +27,7 @@
   <p>
     Is this your current address?
   </p>
-  <form action="confirm-dob" method="get" class="form">
+  <form action="eligible" method="get" class="form">
     <div class="form-group">
       <fieldset class="inline">
 

--- a/app/views/service-patterns/concessionary-travel/example-service/confirm-dob.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/confirm-dob.html
@@ -24,7 +24,7 @@
   <p>
     Is this your date of birth?
   </p>
-  <form action="eligible" method="get" class="form">
+  <form action="confirm-address" method="get" class="form">
     <div class="form-group">
       <fieldset class="inline">
 

--- a/app/views/service-patterns/concessionary-travel/example-service/incorrect-address.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/incorrect-address.html
@@ -11,7 +11,7 @@
   <h1 class="heading-xlarge">Enter your current address</h1>
 
   <div>
-      <form method="post">
+      <form method="post" action="eligible">
           <fieldset>
               <legend class="visuallyhidden">Enter current address</legend>
 
@@ -35,7 +35,7 @@
                     </label>
                     <input class="form-control" id="postcode" name="postcode" type="text">
                 </div>
-
+                <input class="button" type="submit" value="Next">
               </div>
           </fieldset>
       </form>
@@ -50,7 +50,6 @@
   </strong>
 </div>
 
-  <a class="button" role="button" href="confirm-dob">Next</a>
 
 
 </main>

--- a/app/views/service-patterns/concessionary-travel/index.html
+++ b/app/views/service-patterns/concessionary-travel/index.html
@@ -183,36 +183,11 @@
                             </li>
                         </ol>
                     </li>
-                    <li>
-                      <h3 class="heading-small">Do you already have a bus pass?</h3>
+                  <li>
+                      <h3 class="heading-small">Confirm your date of birth</h3>
                       <p>
                         If the user has been successfully verified, The council will receive the user's name, address, and date of birth from GOV.UK Verify.
                       </p>
-                      <p>
-                        At this point the council should check whether or not they have a bus pass against their records. If they already have a pass, they should tell them they are not eligible to apply for a new one, but they can renew or replace a lost or stolen one with the 'Renew or replace your bus pass' service. The page should also include a link to contact the council if the user believes there has been a mistake.</p>
-
-                      <a href="concessionary-travel/example-service/not-eligible-pass">See the page telling the user they are not eligible because they already have a pass</a>
-                    </li>
-                    <li>
-                        <h3 class="heading-small">Confirm your address</h3>
-                        <p>
-                            GOV.UK Verify will send the council the user's address, as known by the user's chosen identity provider. On returning from the GOV.UK Verify process, the council should ask the user to confirm whether or not this is their current address. This page
-                            can also ask the user to confirm they want the council to send the bus pass to the address they've received through GOV.UK Verify.
-                        </p>
-                        <a href="concessionary-travel/example-service/confirm-address">See the example page asking users to confirm their name and address</a>
-                        <p>
-                            If the user says the address returned is not correct, they are likely to be a new resident whose address has not been updated with their identity provider. The user should then be asked to enter their current address and warned that they must not
-                            enter false information as this is a civic offence. If the travel pass is physical, councils will get extra confidence in the address by mailing the pass to the address given. Councils should mention they will be using the address for this purpose on
-                            the confirmation page.
-                        </p>
-                        <a href="concessionary-travel/example-service/incorrect-address">See the example page asking users to enter their current address</a>
-                        <p>
-                            Once the user has confirmed their address, the council should check that the given address is in the area the council serves. If the address is not in the area, the council should tell them they are not eligible in this area.
-                        </p>
-                        <a href="concessionary-travel/example-service/not-eligible-address">See the page telling the user they are not eligible because of their address</a>
-                  </li>
-                  <li>
-                      <h3 class="heading-small">Confirm your date of birth</h3>
                       <p>
                         The council should show the user their date of birth for the user to confirm it. (This is mainly done because of a legal requirement to show user's the data that has been received from GOV.UK Verify.)
                       </p>
@@ -228,6 +203,33 @@
 
                       <a href="concessionary-travel/example-service/not-eligible-age">See the page telling the user they are not eligible because of their age</a>
 
+                    </li>
+                    <li>
+                        <h3 class="heading-small">Confirm your address</h3>
+                        <p>
+                            GOV.UK Verify will send the council the user's address, as known by the user's chosen identity provider. On returning from the GOV.UK Verify process, the council should ask the user to confirm whether or not this is their current address. (This is mainly done because GOV.UK Verify identity providers may not have the user's address if they moved house in the last 3 months.)
+                        </p>
+                        <p>
+                          This page can also ask the user to confirm they want the council to send the bus pass to the address they've received through GOV.UK Verify.
+                        </p>
+                        <a href="concessionary-travel/example-service/confirm-address">See the example page asking users to confirm their name and address</a>
+                        <p>
+                            If the user says the address returned is not correct, they are likely to be a new resident whose address has not been updated with their identity provider. The user should then be asked to enter their current address and warned that they must not
+                            enter false information as this is a civic offence. If the travel pass is physical, councils will get extra confidence in the address by mailing the pass to the address given. Councils should mention they will be using the address for this purpose on
+                            the confirmation page.
+                        </p>
+                        <a href="concessionary-travel/example-service/incorrect-address">See the example page asking users to enter their current address</a>
+                        <p>
+                            Once the user has confirmed their address, the council should check that the given address is in the area the council serves. If the address is not in the area, the council should tell them they are not eligible in this area.
+                        </p>
+                        <a href="concessionary-travel/example-service/not-eligible-address">See the page telling the user they are not eligible because of their address</a>
+                  </li>
+                    <li>
+                      <h3 class="heading-small">Do you already have a bus pass?</h3>
+                      <p>
+                        At this point the council should check whether or not they have a bus pass against their records. If they already have a pass, they should tell them they are not eligible to apply for a new one, but they can renew or replace a lost or stolen one with the 'Renew or replace your bus pass' service. The page should also include a link to contact the council if the user believes there has been a mistake.</p>
+
+                      <a href="concessionary-travel/example-service/not-eligible-pass">See the page telling the user they are not eligible because they already have a pass</a>
                     </li>
                     <li>
                         <h3 class="heading-small">Upload passport style photograph</h3>


### PR DESCRIPTION
The new order once a user returns from Verify is:

1. Confirm Date of Birth
2. Confirm Address
3. (In the background) check for existing permits

Addresses #170 & #174 