### PR TITLE
Add card details to session storage and display them on payment screen

### DIFF
--- a/app/views/service-patterns/parking-permit/example-service/confirm-card-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/confirm-card-payment.html
@@ -12,7 +12,7 @@
 		    <tbody>
 		      <tr>
 		        <td>Card number:</td>
-		        <td class="table-info">{{cardNumber}}</td>
+		        <td class="table-info">**** **** **** {{cardNumber.substr(cardNumber.length - 4) }}</td>
 		      </tr>
 		      <tr>
 		       <td>Expiry date:</td>
@@ -24,7 +24,7 @@
 		      </tr>
 		      <tr>
 		        <td>Billing address:</td>
-		        <td class="table-info">{{buildingStreet}} {{townCity}}, {{postcode}}</td>
+		        <td class="table-info">{{buildingStreet}}, {{townCity}}, {{postcode}}</td>
 		      </tr>
 		       <tr>
 		        <td>Email address:</td>

--- a/app/views/service-patterns/parking-permit/example-service/confirm-card-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/confirm-card-payment.html
@@ -12,23 +12,23 @@
 		    <tbody>
 		      <tr>
 		        <td>Card number:</td>
-		        <td class="table-info">************7470</td>
+		        <td class="table-info">{{cardNumber}}</td>
 		      </tr>
 		      <tr>
 		       <td>Expiry date:</td>
-		        <td class="table-info">{{exp-month}}/{{exp-year}}</td>
+		        <td class="table-info">{{expMonth}}/{{expYear}}</td>
 		      </tr>
 		      <tr>
 		        <td>Name on card:</td>
-		        <td class="table-info">{{full-name}}</td>
+		        <td class="table-info">{{cardName}}</td>
 		      </tr>
 		      <tr>
 		        <td>Billing address:</td>
-		        <td class="table-info">{{building-and-street}} {{town-or-city}}, {{postcode}}</td>
+		        <td class="table-info">{{buildingStreet}} {{townCity}}, {{postcode}}</td>
 		      </tr>
 		       <tr>
 		        <td>Email address:</td>
-		        <td class="table-info">{{email-address}}</td>
+		        <td class="table-info">{{email}}</td>
 		      </tr>
 		      <tr>
 		        <td>Payment of:</td>

--- a/app/views/service-patterns/parking-permit/example-service/confirm-debit-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/confirm-debit-payment.html
@@ -1,0 +1,53 @@
+{% extends "layout_picker.html" %}
+
+{% set serviceName = "Apply for a resident's parking permit" %}
+{% set pageTitle = "Confirm your payment" %}
+
+{% block content %}
+
+<div class="grid-row review-details">
+	  <div class="check-details">
+
+	  	<table>
+		    <tbody>
+		      <tr>
+		        <td>Account number:</td>
+		        <td class="table-info">**** **** **** {{accountNumber.substr(accountNumber.length - 4) }}</td>
+		      </tr>
+		      <tr>
+		        <td>Name on account:</td>
+		        <td class="table-info">{{nameAccount}}</td>
+		      </tr>
+		      <tr>
+		        <td>Billing address:</td>
+		        <td class="table-info">{{buildingStreet}}, {{townCity}}, {{postcode}}</td>
+		      </tr>
+		       <tr>
+		        <td>Email address:</td>
+		        <td class="table-info">{{email}}</td>
+		      </tr>
+		      <tr>
+		        <td>Payment of:</td>
+		        <td class="table-info">Resident's parking permit</td>
+		      </tr>
+		      <tr>
+		        <td>Amount to pay:</td>
+		        <td class="table-info">£60.00</td>
+		      </tr>
+		    </tbody>
+  		</table>
+		</div>
+</div>
+
+	<div class="grid-row">
+		<div class="column-two-thirds">
+			<div class="form-group">
+		 			<a href="success"><button class="button">Confirm payment</button></a>
+		 		</div>
+		 		<div class="back">
+				<a href="#">Cancel payment</a>
+			</div>
+		 </div>
+	 </div>
+
+{% endblock %}

--- a/app/views/service-patterns/parking-permit/example-service/direct-debit-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/direct-debit-payment.html
@@ -1,125 +1,115 @@
-{% extends "layout_picker.html" %}
-
-{% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Pay by Direct Debit" %}
-
-{% block content %}
+{% extends "layout_picker.html" %} {% set serviceName = "Apply for a resident's parking permit" %} {% set pageTitle = "Pay by Direct Debit" %} {% block content %}
 
 <div class="column-two-thirds">
-  	<div class="payment-type-intro">
-  		<p>We will use Direct Debit to take a one-off payment from your bank account. Please fill in your details below.</p>
-  	</div>
+    <div class="payment-type-intro">
+        <p>We will use Direct Debit to take a one-off payment from your bank account. Please fill in your details below.</p>
+    </div>
 
-	<form class="form" method="POST" action="/benefit-direct-debit-payment-2">
-		  	<div class="form-group">
-				<label class="form-label-bold" for="name-on-account">
-			    Name on the account
+    <form class="form" method="POST" action="confirm-debit-payment">
+        <div class="form-group">
+          <label class="form-label-bold" for="nameAccount">
+			         Name on the account
 			  	</label>
-			  	<input class="form-control" id="name-on-account" name="name-on-account" type="text">
-			 </div>
+          <input class="form-control" id="nameAccount" name="nameAccount" type="text">
+        </div>
 
-			<div class="form-group">
-				<label class="form-label-bold" for="full-name">
-			    Sort code
+        <div class="form-group">
+          <label class="form-label-bold" for="full-name">
+			      Sort code
 			  	</label>
-			  	<input class="form-control" id="sort-code" name="sort-code" type="text">
-			</div>
-			<div class="form-group">
-				<label class="form-label-bold" for="card-number">
-			    Account number
+          <input class="form-control" id="sortCode" name="sortCode" type="text">
+        </div>
+        <div class="form-group">
+          <label class="form-label-bold" for="accountNumber">
+			      Account number
 			  	</label>
-			  	<input class="form-control" id="account-number" name="account-number" type="text">
-			</div>
+          <input class="form-control" id="accountNumber" name="accountNumber" type="text">
+        </div>
 
-	 	<fieldset class="inline">
-		    	<h2>Is more than one person required to authorise debits on this account?</h2>
-				    <label class="block-label" for="radio-inline-1">
+        <fieldset class="inline">
+            <h2>Is more than one person required to authorise debits on this account?</h2>
+            <label class="block-label" for="radio-inline-1">
 				      <input id="radio-inline-1" type="radio" name="radio-inline-group" value="Yes">
 				      Yes
 				    </label>
-				    <label class="block-label" for="radio-inline-2">
+            <label class="block-label" for="radio-inline-2">
 				      <input id="radio-inline-2" type="radio" name="radio-inline-group" value="No">
 				      No
 				    </label>
-  		</fieldset>
+        </fieldset>
 
 
-	 <div class="form-group">
-      <h2 class="heading-medium">Billing address</h2>
-      <div class="payment-type-intro">
-  		<p>This is where your statements are sent</p>
-  		</div>
+        <div class="form-group">
+            <h2 class="heading-medium">Billing address</h2>
+            <div class="payment-type-intro">
+                <p>This is where your statements are sent</p>
+            </div>
 
-			<div class="form-group">
-				<label class="form-label-bold" for="building-and-street">
-			    Building name/number and street
-			  	</label>
-			  	<input class="form-control" id="building-and-street" type="text">
-			  	<input class="form-control" id="building-and-street" type="text">
-			  	<input class="form-control" id="building-and-street" type="text">
-			</div>
-			<div class="form-group">
-				<label class="form-label-bold" for="town-or-city">
-			    Town or city
-			  	</label>
-			  	<input class="form-control" id="town-or-city" type="text">
-			</div>
-			<div class="form-group">
-				<label class="form-label-bold" for="county">
-			    County (optional)
-			  	</label>
-			  	<input class="form-control" id="county" type="text">
-			</div>
-			<div class="form-group">
-				<label class="form-label-bold" for="postcode">
-			    Postcode
-			  	</label>
-			  	<input class="form-control" id="postcode" type="text">
-			</div>
-			<div class="form-group">
-				<label class="form-label-bold" for="email-address">Email address<span class="form-hint">We need this to confirm the Direct Debit with you</span>
-			  	</label>
-			  	<input class="form-control" id="email-address" type="text">
-			</div>
-		</div>
+            <div class="form-group">
+      				<label class="form-label-bold" for="buildingStreet">
+      			    Building name and/or number and street
+      			  	</label>
+      			  	<input class="form-control" id="buildingStreet" name="buildingStreet" type="text">
+      			  	<input class="form-control" id="buildingStreet" name="buildingStreet" type="text">
+      			</div>
+      			<div class="form-group">
+      				<label class="form-label-bold" for="townCity">
+      			    Town or city
+      			  	</label>
+      			  	<input class="form-control medium-width" id="townCity" name="townCity" type="text">
+      			</div>
+      			<div class="form-group">
+      				<label class="form-label-bold" for="postcode">
+      			    Postcode
+      			  	</label>
+      			  	<input class="form-control" id="postcode" name="postcode" type="text">
+      			</div>
 
-	</div>
+            <div class="form-group">
+              <label class="form-label-bold" for="email">Email address
+                <span class="form-hint">We need this to confirm the Direct Debit with you</span>
+                </label>
+                <input class="form-control" id="email" name="email" type="text">
+            </div>
+        </div>
 
-
-
-	<div class="column-third">
-
-			<div class="payment-summary payment-summary-small">
-				<h2>Payment summary</h2>
-			      <p class="payment-info">Resident's parking permit</p>
-			       <h3>Amount:</h3>
-			       <p class="payment-amount">£60.00</p>
-			</div>
-	</div>
 </div>
 
-	<div class="grid-row">
-	    <div class="column-two-thirds">
-		<div class="form-group">
-	 			<button class="button">Continue</button>
-	 	</div>
-	 	<div class="back">
-				<a href="#">Cancel</a>
-			</div>
-	 	</div>
-	 </div>
-	 </form>
 
-	<div class="grid-row">
-	    <div class="column-two-thirds">
-	    <div class="DD-terms-conditions">
-		 <!-- <div class="dd-images"><img src="/public/images/gocardless.png"><img src="/public/images/directdebit.png"></div> -->
-			 <p>Your payments are protected by the <a>Direct Debit guarantee</a>.</p>
-			<p>GoCardless Ltd, 338-346 Goswell Road, London, EC1V 7LQ.</p>
-			<p>E-mail: help@gocardless.com / Tel: 020 7183 8674</p>
-		 </div>
-		</div>
-	 </div>
+
+<div class="column-third">
+
+    <div class="payment-summary payment-summary-small">
+        <h2>Payment summary</h2>
+        <p class="payment-info">Resident's parking permit</p>
+        <h3>Amount:</h3>
+        <p class="payment-amount">£60.00</p>
+    </div>
+</div>
+</div>
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <div class="form-group">
+            <input type="submit" class="button" value="Continue">
+        </div>
+        <div class="back">
+            <a href="#">Cancel</a>
+        </div>
+    </div>
+</div>
+</form>
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <div class="DD-terms-conditions">
+            <!-- <div class="dd-images"><img src="/public/images/gocardless.png"><img src="/public/images/directdebit.png"></div> -->
+            <p>Your payments are protected by the <a>Direct Debit guarantee</a>.</p>
+            <p>GoCardless Ltd, 338-346 Goswell Road, London, EC1V 7LQ.</p>
+            <p>E-mail: help@gocardless.com / Tel: 020 7183 8674</p>
+        </div>
+    </div>
+</div>
 
 </main>
 

--- a/app/views/service-patterns/parking-permit/example-service/enter-card.html
+++ b/app/views/service-patterns/parking-permit/example-service/enter-card.html
@@ -7,49 +7,51 @@
 
 <div class="column-two-thirds">
 
-	<form class="form" method="GET" action="confirm-card-payment" autocomplete="off">
+	<form class="form" method="POST" action="confirm-card-payment" autocomplete="off">
 
 		<div class="form-group cards-group">
-			<label class="form-label-bold" for="card-number">
+			<label class="form-label-bold" for="cardNumber">
 		    Card number
-		  	</label>
-		  	<input class="form-control medium-width" id="card-number" type="number" pattern="[0-9]*" min="0" max="9999999999999999">
-		  	<div class="card-images">
-          <p class="accepted-copy-2">Accepted credit and debit card types</p>
-			  	<img class="original-accepted" id="original-accepted" src="/public/images/accepted-cards-x2.png">
-		  	</div>
+		  </label>
+		  <input class="form-control medium-width" id="cardNumber" name="cardNumber" type="number" pattern="[0-9]*" min="0" max="9999999999999999">
+		  <div class="card-images">
+        <p class="accepted-copy-2">Accepted credit and debit card types</p>
+			  <img class="original-accepted" id="original-accepted" src="/public/images/accepted-cards-x2.png">
+		  </div>
 		</div>
 
 		<div class="form-group">
-      		<fieldset>
-      		  <div class="form-date">
-        		<legend class="form-label-bold">Expiry date	<span class="form-hint">For example, 07/17</span>
-        		</legend>
-		          <div class="form-group form-group-month">
-        		    <label for="exp-month">Month</label>
-            		<input class="form-control" id="exp-month" name="exp-month" type="number" pattern="[0-9]*" min="1" max="12">
-		          </div>
-        		  <div class="form-group form-group-month">
-	            	<label for="exp-year">Year</label>
-    	        	<input class="form-control" id="exp-year" name="exp-year" type="number" pattern="[0-9]*" min="16" max="25">
-          		</div>
-        	</div>
-       		</fieldset>
-      	</div>
+			<fieldset>
+			  <div class="form-date">
+					<legend class="form-label-bold">
+						Expiry date
+						<span class="form-hint">For example, 07/17</span>
+					</legend>
+			    <div class="form-group form-group-month">
+				    <label for="expMonth">Month</label>
+			  		<input class="form-control" id="expMonth" name="expMonth" type="number" pattern="[0-9]*" min="1" max="12">
+			    </div>
+				  <div class="form-group form-group-month">
+			    	<label for="expYear">Year</label>
+			    	<input class="form-control" id="expYear" name="expYear" type="number" pattern="[0-9]*" min="17" max="27">
+					</div>
+				</div>
+			</fieldset>
+		</div>
 
       	<div class="form-group">
-			<label class="form-label-bold" for="full-name">
+			<label class="form-label-bold" for="cardName">
 		    	Name on card
 		  	</label>
-		  	<input class="form-control" id="full-name" name="full-name" type="text">
+		  	<input class="form-control" id="cardName" name="cardName" type="text">
 		</div>
 
 		<div class="form-group">
-			<label class="form-label-bold" for="card-security-number">
+			<label class="form-label-bold" for="cardSecurityNumber">
 		    Card security code
 		    <span class="form-hint">This is the 3 digit code on the back of your card</span>
 		  	</label>
-		  	<input class="form-control" id="security-number" type="number" pattern="[0-9]*" min="0" max="999"><img class="card-image" src="/public/images/card-security-code-2.png">
+		  	<input class="form-control" id="cardSecurityNumber" name="cardSecurityNumber" type="number" pattern="[0-9]*" min="0" max="999"><img class="card-image" src="/public/images/card-security-code-2.png">
 		</div>
 
       <div class="form-group">
@@ -59,17 +61,17 @@
   		</div>
       	<fieldset>
 			<div class="form-group">
-				<label class="form-label-bold" for="building-and-street">
+				<label class="form-label-bold" for="buildingStreet">
 			    Building name and/or number and street
 			  	</label>
-			  	<input class="form-control" id="building-and-street" name="building-and-street" type="text">
-			  	<input class="form-control" id="building-and-street" name="building-and-street" type="text">
+			  	<input class="form-control" id="buildingStreet" name="buildingStreet" type="text">
+			  	<input class="form-control" id="buildingStreet" name="buildingStreet" type="text">
 			</div>
 			<div class="form-group">
-				<label class="form-label-bold" for="town-or-city">
+				<label class="form-label-bold" for="townCity">
 			    Town or city
 			  	</label>
-			  	<input class="form-control medium-width" id="town-or-city" name="town-or-city" type="text">
+			  	<input class="form-control medium-width" id="townCity" name="townCity" type="text">
 			</div>
 			<div class="form-group">
 				<label class="form-label-bold" for="postcode">
@@ -78,9 +80,9 @@
 			  	<input class="form-control" id="postcode" name="postcode" type="text">
 			</div>
 			<div class="form-group">
-				<label class="form-label-bold" for="email-address">Email address<span class="form-hint">We'll send your payment confirmation here</span>
+				<label class="form-label-bold" for="email">Email address<span class="form-hint">We'll send your payment confirmation here</span>
 			  	</label>
-			  	<input class="form-control" id="email-address" name="email-address" type="text">
+			  	<input class="form-control" id="email" name="email" type="text">
 			</div>
 			</fieldset>
 		</div>
@@ -88,7 +90,7 @@
 		<div class="grid-row">
 			<div class="column-two-thirds">
 				<div class="form-group">
-			 		<button class="button">Continue</button>
+					<input type="submit" class="button" value="Continue">
 			 	</div>
 			 	<div class="back">
 					<a href="#">Cancel payment</a>


### PR DESCRIPTION
Not really much point doing a before / after screenshot here, but all the details entered in both the pay by card and pay by debit pages now go through to the next page for the user to confirm.

<img width="1440" alt="screen shot 2017-03-03 at 16 37 49" src="https://cloud.githubusercontent.com/assets/4106955/23559822/29f0ca20-0030-11e7-9ec8-bf7f96ce6622.png">
<img width="1440" alt="screen shot 2017-03-03 at 16 11 40" src="https://cloud.githubusercontent.com/assets/4106955/23559821/29ea1298-0030-11e7-9db5-b7b8f52e7e25.png">

