### PR TITLE
Add contact details and some confirmation page improvements

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -5,7 +5,7 @@
     "parkingBoundary": "Argleton City Centre",
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
-    "permitWait": 0,
+    "permitWait": 5,
     "string" : "argleton"
   },
   {
@@ -14,7 +14,7 @@
     "parkingBoundary" : "Unbrandedland City",
     "permitMax": "sixty seven",
     "permitsCosts": [67, 77, 100, 100],
-    "permitWait": 5,
+    "permitWait": 0,
     "string" : "unbranded"
   }
 ]

--- a/app/views/service-patterns/parking-permit/example-service/confirm-card-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/confirm-card-payment.html
@@ -46,7 +46,7 @@
 	<div class="grid-row">
 		<div class="column-two-thirds">
 			<div class="form-group">
-		 			<a href="success"><button class="button">Confirm payment</button></a>
+		 			<a href="contact-details"><button class="button">Confirm payment</button></a>
 		 		</div>
 		 		<div class="back">
 				<a href="#">Cancel payment</a>

--- a/app/views/service-patterns/parking-permit/example-service/contact-details.html
+++ b/app/views/service-patterns/parking-permit/example-service/contact-details.html
@@ -7,14 +7,14 @@
 
 <div class="column-two-thirds">
 <p>We'll send you a confirmation of your payment{% if council.permitWait > 0 %} and an alert when your permit is on it's way{% endif %}.</p>
-<form>
+<form method="post" action="success">
   <div class="form-group">
     <fieldset>
 
       <legend class="visually-hidden">How do you want to be contacted?</legend>
 
       <label class="block-label selection-button-radio" data-target="contact-by-email" for="example-contact-by-email">
-        <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Email">
+        <input id="example-contact-by-email" type="radio" name="contactChoice" value="Email">
         Email
       </label>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
@@ -23,8 +23,8 @@
       </div>
 
       <label class="block-label selection-button-radio" data-target="contact-by-phone" for="example-contact-by-phone">
-        <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="Phone">
-        Phone
+        <input id="example-contact-by-phone" type="radio" name="contactChoice" value="Phone">
+        Automated phone call
       </label>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
         <label class="form-label" for="contact-phone">Phone number</label>
@@ -32,7 +32,7 @@
       </div>
 
       <label class="block-label selection-button-radio" data-target="contact-by-text" for="example-contact-by-text">
-        <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="Text">
+        <input id="example-contact-by-text" type="radio" name="contactChoice" value="Text">
         Text message
       </label>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
@@ -41,18 +41,16 @@
       </div>
 
       <label class="block-label selection-button-radio" for="no-contact">
-        <input id="no-contact" type="radio" name="radio-contact-group" value="No">
+        <input id="no-contact" type="radio" name="contactChoice" value="No">
         I don't want to receive a confirmation or progress alerts
       </label>
 
     </fieldset>
   </div>
+  <div class="form-group">
+    <input type="submit" class="button" name="Continue">
+  </div>
 </form>
-
-<div>
-
-   <a class="button" role="button" href="/choose-payment">Next</a>
-</div>
 
 </div>
 

--- a/app/views/service-patterns/parking-permit/example-service/contact-details.html
+++ b/app/views/service-patterns/parking-permit/example-service/contact-details.html
@@ -7,6 +7,11 @@
 
 <div class="column-two-thirds">
 <p>We'll send you a confirmation of your payment{% if council.permitWait > 0 %} and an alert when your permit is on it's way{% endif %}.</p>
+
+<h2 class="heading-medium">How do you want to be contacted?</h2>
+<p>
+  Select one option.
+</p>
 <form method="post" action="success">
   <div class="form-group">
     <fieldset>

--- a/app/views/service-patterns/parking-permit/example-service/contact-details.html
+++ b/app/views/service-patterns/parking-permit/example-service/contact-details.html
@@ -1,12 +1,12 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Add contact details" %}
+{% set pageTitle = "Sign up for confirmation and alerts" %}
 
 {% block content %}
 
 <div class="column-two-thirds">
-<p> We will only contact you in regards to your application for a parking permit.</p>
+<p>We'll send you a confirmation of your payment{% if council.permitWait > 0 %} and an alert when your permit is on it's way{% endif %}.</p>
 <form>
   <div class="form-group">
     <fieldset>
@@ -14,7 +14,7 @@
       <legend class="visually-hidden">How do you want to be contacted?</legend>
 
       <label class="block-label selection-button-radio" data-target="contact-by-email" for="example-contact-by-email">
-        <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Yes">
+        <input id="example-contact-by-email" type="radio" name="radio-contact-group" value="Email">
         Email
       </label>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-email">
@@ -23,7 +23,7 @@
       </div>
 
       <label class="block-label selection-button-radio" data-target="contact-by-phone" for="example-contact-by-phone">
-        <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="No">
+        <input id="example-contact-by-phone" type="radio" name="radio-contact-group" value="Phone">
         Phone
       </label>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-phone">
@@ -32,13 +32,18 @@
       </div>
 
       <label class="block-label selection-button-radio" data-target="contact-by-text" for="example-contact-by-text">
-        <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="No">
+        <input id="example-contact-by-text" type="radio" name="radio-contact-group" value="Text">
         Text message
       </label>
       <div class="panel panel-border-narrow js-hidden" id="contact-by-text">
         <label class="form-label" for="contact-text-message">Mobile phone number</label>
         <input class="form-control" name="contact-text-message" type="text" id="contact-text-message">
       </div>
+
+      <label class="block-label selection-button-radio" for="no-contact">
+        <input id="no-contact" type="radio" name="radio-contact-group" value="No">
+        I don't want to receive a confirmation or progress alerts
+      </label>
 
     </fieldset>
   </div>

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -25,6 +25,18 @@
       You can expect your permit to arrive within 5 working days.
     </p>
     <p>
+      We'll send it to this address:
+    </p>
+    <div class="panel panel-border-wide">
+      <p>
+        {% if skip_verify == true %}Jane Smith{% else %}Jane Smith{% endif %}<br />
+        1A {{council.shortName}} High Street<br />
+        {{council.shortName}}<br />
+        ARG1 4HP<br />
+      </p>
+      <a href="#">Provide a different address</a>
+    </div>
+    <p>
       In the mean time, you can print this <a href="#">temporary permit</a> and display it in your car window.
     </p>
     {% endif %}

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -5,7 +5,6 @@
 
 {% block content %}
 
-
   <div class="govuk-box-highlight">
     <p>
       Your reference number is <br>
@@ -13,9 +12,20 @@
     </p>
   </div>
 	<p><a href="#"> Request</a> a confirmation email.</p>
-
-<div>Your parking permit is on its way. You can expect your permit to arrive within 5 working days. In the mean time, you can print this <a href="#">temporary permit</a> and display it in your car window.
-</div>
+  <div class="column-two-thirds">
+    {% if council.permitWait < 1 %}
+    <p>
+      You won't receive a physical permit. Wardens will check your vehicle's registration number.
+    </p>
+    {% else %}
+    <p>
+      You can expect your permit to arrive within 5 working days.
+    </p>
+    <p>
+      In the mean time, you can print this <a href="#">temporary permit</a> and display it in your car window.
+    </p>
+    {% endif %}
+  </div>
 
 
 </main>

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -5,14 +5,17 @@
 
 {% block content %}
 
-  <div class="govuk-box-highlight">
-    <p>
-      Your reference number is <br>
-      <strong class="heading-large">HDJ2123F</strong>
-    </p>
-  </div>
-	<p><a href="#"> Request</a> a confirmation email.</p>
   <div class="column-two-thirds">
+    {% if contactChoice == 'Email' %}
+    <p>You should receive a confirmation email within the next minute.</p>
+    {% elif contactChoice == 'Phone' %}
+    <p>You should receive a confirmation phone call within the next minute.</p>
+    {% elif contactChoice == 'Text' %}
+    <p>You should receive a confirmation text within the next minute.</p>
+    {% else %}
+    <p>You have not signed up to receive a confirmation email. <a href="contact-details">Sign up for confirmation and progress alerts.</a></p>
+    {% endif %}
+
     {% if council.permitWait < 1 %}
     <p>
       You won't receive a physical permit. Wardens will check your vehicle's registration number.


### PR DESCRIPTION
Added in the page to sign up for a confirmation alert and progress alerts, plus some alterations to the success page to work with that. Success page displays different info depending on what shows. This reflects what the research presented in #185. 

Also makes what shows on the confirmation page consistent with start page in regards to wait time, to fix #219. Argleton now does physical permits, to reflect most councils on the pilots.

**Before**
<img width="1440" alt="screen shot 2017-03-03 at 18 05 51" src="https://cloud.githubusercontent.com/assets/4106955/23562858/0fd59c04-003c-11e7-88da-50ae55f92151.png">

**After**
![screenshot-localhost-3000 2017-03-03 18-04-03](https://cloud.githubusercontent.com/assets/4106955/23562767/d2a26420-003b-11e7-856d-664b263e0b19.png)
<img width="1440" alt="screen shot 2017-03-03 at 18 04 47" src="https://cloud.githubusercontent.com/assets/4106955/23562804/ee22d0fe-003b-11e7-907e-7746b68d63dd.png">
