### PR TITLE
Boundaries

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -8,6 +8,25 @@ router.get('/', function (req, res) {
 
 // add your routes here
 
+router.get('/service-patterns/parking-permit/example-service/resident-choice', function (req, res) {
+
+  // get the answer from the query string (eg. ?over18=false)
+  var resident = req.query['resident'];
+
+  if (resident){
+
+    // redirect to the relevant page
+    res.redirect(resident);
+
+  } else {
+
+    // if radio-group is any other value (or is missing) render the page requested
+    res.render('service-patterns/parking-permit/example-service/resident-choice');
+
+  }
+
+});
+
 router.get('/service-patterns/parking-permit/example-service/choose-payment', function (req, res) {
 
   // get the answer from the query string (eg. ?over18=false)

--- a/app/views/service-patterns/parking-permit/example-service/check-boundary.html
+++ b/app/views/service-patterns/parking-permit/example-service/check-boundary.html
@@ -1,0 +1,38 @@
+{% extends "layout_picker.html" %}
+
+{% set serviceName = "Park your car or vehicle" %}
+{% set pageTitle = "Check if you need a permit" %}
+
+{% block content %}
+
+<div class="column-two-thirds">
+
+  <p>
+    To check if you need a permit, enter the postcode of the area where you'd like to park.
+  </p>
+
+  <div class="postcode-search-form" data-module="track-submit" data-track-category="postcodeSearch:find_local_council" data-track-action="postcodeSearchStarted">
+
+    <form method="post" action="resident-choice" id="local-locator-form" class="find-location-for-service">
+      <fieldset>
+        <legend class="visuallyhidden">Postcode lookup</legend>
+
+        <div class="ask_location">
+          <label class="heading-small" for="postcode">Enter a postcode</label>
+          <p>For example SW1A 2AA</p>
+          <input class="postcode" id="postcode" name="postcode" type="text" aria-invalid="false" value="">
+          <input type="submit" class="button" value="Find">
+          <p>
+            <a target="_blank" id="postcode-finder-link" rel="external" href="http://www.royalmail.com/find-a-postcode">Find a postcode on Royal Mail's postcode finder</a>
+          </p>
+        </div>
+      </fieldset>
+
+    </form>
+  </div>
+
+
+
+</div>
+
+{% endblock %}

--- a/app/views/service-patterns/parking-permit/example-service/no-permits.html
+++ b/app/views/service-patterns/parking-permit/example-service/no-permits.html
@@ -1,0 +1,51 @@
+{% extends "layout_picker.html" %}
+
+{% set serviceName = "Park your car or vehicle" %}
+{% set pageTitle = "No permits available" %}
+
+{% block content %}
+
+<div class="column-two-thirds">
+
+  <p>
+    You've told us you want to park in {{postcode}}, which is inside the {{council.parkingBoundary}} parking boundary.
+  </p>
+  <p>
+    There are currently no permits available in {{council.parkingBoundary}}. You'll need to select a new area to park in.
+  </p>
+
+  <h2 class="heading-medium">Select an area to park in</h2>
+  <p>
+    The nearest areas which have parking permits available are
+  </p>
+
+  <form>
+  <div class="form-group">
+    <fieldset>
+
+      <legend class="visually-hidden">Where do you live?</legend>
+
+      <label class="block-label selection-button-radio" for="radio-1">
+        <input id="radio-1" type="radio" name="radio-group" value="Northern Ireland">
+        Argletonshire
+      </label>
+      <label class="block-label selection-button-radio" for="radio-2">
+        <input id="radio-2" type="radio" name="radio-group" value="Isle of Man or the Channel Islands">
+        Argleton beach
+      </label>
+      <p class="form-block">or</p>
+      <label class="block-label selection-button-radio" for="radio-3">
+        <input id="radio-3" type="radio" name="radio-group" value="I am a British citizen living abroad">
+        Little Argleton
+      </label>
+
+    </fieldset>
+  </div>
+  <div class="form-group">
+    <button class="button">Continue</button>
+  </div>
+</form>
+
+</div>
+
+{% endblock %}

--- a/app/views/service-patterns/parking-permit/example-service/resident-choice.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-choice.html
@@ -13,7 +13,7 @@
 
   <h2 class="heading-medium">Are you a resident of {{council.parkingBoundary}}?</h2>
 
-  <form action="resident-start" method="get">
+  <form class="radio-nav">
   <div class="form-group">
     <fieldset>
 
@@ -31,7 +31,7 @@
     </fieldset>
   </div>
   <div class="form-group">
-    <input type="submit" class="button" value="Continue">
+    <button class="button">Continue</button>
   </div>
 </form>
 

--- a/app/views/service-patterns/parking-permit/example-service/resident-choice.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-choice.html
@@ -1,0 +1,41 @@
+{% extends "layout_picker.html" %}
+
+{% set serviceName = "Park your car or vehicle" %}
+{% set pageTitle = "You need a parking permit" %}
+
+{% block content %}
+
+<div class="column-two-thirds">
+
+  <p>
+    {{postcode}} is within {{council.parkingBoundary}}, so you'll need a parking permit.
+  </p>
+
+  <h2 class="heading-medium">Are you a resident of {{council.parkingBoundary}}?</h2>
+
+  <form action="resident-start" method="get">
+  <div class="form-group">
+    <fieldset>
+
+      <legend class="visually-hidden">Are you a resident of {{council.parkingBoundary}}?</legend>
+
+      <label class="block-label selection-button-radio" for="radio-1">
+        <input id="radio-1" type="radio" name="resident" value="resident-start">
+        Yes, I'm a resident
+      </label>
+      <label class="block-label selection-button-radio" for="radio-2">
+        <input id="radio-2" type="radio" name="resident" value="visitor-start">
+        No, I'm a visitor
+      </label>
+
+    </fieldset>
+  </div>
+  <div class="form-group">
+    <input type="submit" class="button" value="Continue">
+  </div>
+</form>
+
+
+</div>
+
+{% endblock %}

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -1,0 +1,76 @@
+{% extends "layout_picker.html" %}
+
+{% set serviceName = "Apply for a parking permit" %}
+{% set pageTitle = "Apply for a resident's parking permit" %}
+
+{% block content %}
+
+<div class="column-two-thirds">
+
+  <p>
+    Residents of {{council.parkingBoundary}} can buy resident's parking permits.
+  </p>
+  <p>
+    These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
+  </p>
+
+  <h2 class="heading-medium">About this service</h2>
+    <ul class="list list-bullet">
+      <li>
+        Each household is allowed up to {{council.permitMax}} permits.
+      </li>
+      <li>
+        Permits can be bought for 6 months or for 12 months.
+      </li>
+       <li>
+         Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}} depending on your vehicle type and how many other other permits have been bought by your household.
+      </li>
+      {% if council.permitWait < 1 %}
+      <li>
+        You won't receive a physical permit. Wardens will check your vehicle's registration number.
+      </li>
+      {% else %}
+      <li>
+        Your permit will take {{council.permitWait}} working days to arrive. While you wait, you'll need to use a temporary permit which we will email to you.
+      </li>
+      {% endif %}
+      <li>
+        To apply, you'll need to prove you live in {{council.parkingBoundary}} and provide your vehicle registration number.
+      </li>
+      <li>
+        You can apply using GOV.UK Verify. If you don't already have an account, you'll need to create one which takes around 15 minutes. The rest of the application takes around 2 minutes.
+      </li>
+    </ul>
+
+  <a class="button button-start" href="prove-identity" role="button">Apply online now</a>
+
+  <p>
+    If you need assistance using the online service, <a href="#">contact {{ council.name }}</a>.
+  </p>
+
+  <details>
+     <summary><span class="summary">Other ways to apply</span></summary>
+     <div class="panel panel-border-narrow">
+      <h3 class="heading-small">Apply by phone</h3>
+      <p>0300 083 0013<br>
+      Monday to Friday, 8am to 7pm<br>
+      Saturday, 8am to 2pm<br>
+       <a href="#">Find out about call charges</a></p>
+
+      <h2 class="heading-small">Apply by post</h2>
+      <p>
+      send an <a href="#">application form</a> or a letter with the following information to {{council.name}}:
+      <li>a scanned copy of a council tax statement </li>
+      <li>a scanned copy of a form of identity to prove your age</li> </p>
+      <p>Send your request to: </p>
+      <p>Concessionary travel pass office<br>
+      {{council.name}}<br>
+      12-14 Kings road <br>
+      {{council.shortName}} <br>
+      AG3 4HP </p>
+    </div>
+  </details>
+
+</div>
+
+{% endblock %}

--- a/app/views/service-patterns/parking-permit/example-service/start-page.html
+++ b/app/views/service-patterns/parking-permit/example-service/start-page.html
@@ -1,75 +1,25 @@
 {% extends "layout_picker.html" %}
 
-{% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Apply for a resident's parking permit" %}
+{% set serviceName = "Park your car or vehicle" %}
+{% set pageTitle = "Park your car or vehicle" %}
 
 {% block content %}
 
 <div class="column-two-thirds">
 
   <p>
-    To park in {{council.parkingBoundary}}, you'll need a resident's parking permit.
+    In some parts of {{council.shortName}}, you'll need a parking permit to park your car or other vehicle.
   </p>
   <p>
-    Parking permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
+    Parking permits allow you to park within a given boundary, 24 hours a day and 7 days a week.
   </p>
 
-  <h2 class="heading-medium">About this service</h2>
-    <ul class="list list-bullet">
-      <li>
-        Each household is allowed up to {{council.permitMax}} permits.
-      </li>
-      <li>
-        Permits can be bought for 6 months or for 12 months.
-      </li>
-       <li>
-         Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}} depending on your vehicle type and how many other other permits have been bought by your household.
-      </li>
-      {% if council.permitWait < 1 %}
-      <li>
-        You won't receive a physical permit. Wardens will check your vehicle's registration number.
-      </li>
-      {% else %}
-      <li>
-        Your permit will take {{council.permitWait}} working days to arrive. While you wait, you'll need to use a temporary permit which we will email to you.
-      </li>
-      {% endif %}
-      <li>
-        To apply, you'll need to prove you live in {{council.parkingBoundary}} and provide your vehicle registration number.
-      </li>
-      <li>
-        You can apply using GOV.UK Verify. If you don't already have an account, you'll need to create one which takes around 15 minutes. The rest of the application takes around 2 minutes.
-      </li>
-    </ul>
 
-  <a class="button button-start" href="prove-identity" role="button">Apply online now</a>
+  <a class="button button-start" href="check-boundary" role="button">Check if you need a permit</a>
 
   <p>
-    If you need assistance using the online service, <a href="#">contact {{ council.name }}</a>.
+    If you need assistance using this online service, <a href="#">contact {{ council.name }}</a>.
   </p>
-
-  <details>
-     <summary><span class="summary">Other ways to apply</span></summary>
-     <div class="panel panel-border-narrow">
-      <h3 class="heading-small">Apply by phone</h3>
-      <p>0300 083 0013<br>
-      Monday to Friday, 8am to 7pm<br>
-      Saturday, 8am to 2pm<br>
-       <a href="#">Find out about call charges</a></p>
-
-      <h2 class="heading-small">Apply by post</h2>
-      <p>
-      send an <a href="#">application form</a> or a letter with the following information to {{council.name}}:
-      <li>a scanned copy of a council tax statement </li>
-      <li>a scanned copy of a form of identity to prove your age</li> </p>
-      <p>Send your request to: </p>
-      <p>Concessionary travel pass office<br>
-      {{council.name}}<br>
-      12-14 Kings road <br>
-      {{council.shortName}} <br>
-      AG3 4HP </p>
-    </div>
-  </details>
 
 </div>
 

--- a/app/views/service-patterns/parking-permit/example-service/visitor-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/visitor-start.html
@@ -1,0 +1,48 @@
+{% extends "layout_picker.html" %}
+
+{% set serviceName = "Apply for a parking permit" %}
+{% set pageTitle = "Apply for a visitor's parking permit" %}
+
+{% block content %}
+
+<div class="column-two-thirds">
+
+  <p>
+    Visitors to {{council.parkingBoundary}} can buy visitor's parking permits.
+  </p>
+  <p>
+    These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
+  </p>
+
+  <a class="button button-start" href="#" role="button">Apply online now</a>
+
+  <p>
+    If you need assistance using the online service, <a href="#">contact {{ council.name }}</a>.
+  </p>
+
+  <details>
+     <summary><span class="summary">Other ways to apply</span></summary>
+     <div class="panel panel-border-narrow">
+      <h3 class="heading-small">Apply by phone</h3>
+      <p>0300 083 0013<br>
+      Monday to Friday, 8am to 7pm<br>
+      Saturday, 8am to 2pm<br>
+       <a href="#">Find out about call charges</a></p>
+
+      <h2 class="heading-small">Apply by post</h2>
+      <p>
+      send an <a href="#">application form</a> or a letter with the following information to {{council.name}}:
+      <li>a scanned copy of a council tax statement </li>
+      <li>a scanned copy of a form of identity to prove your age</li> </p>
+      <p>Send your request to: </p>
+      <p>Concessionary travel pass office<br>
+      {{council.name}}<br>
+      12-14 Kings road <br>
+      {{council.shortName}} <br>
+      AG3 4HP </p>
+    </div>
+  </details>
+
+</div>
+
+{% endblock %}

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -50,15 +50,18 @@
                 <h2 class="heading-medium" id="council-need">What do councils need from users to deliver the service?</h2>
                 <p>Depending on local authority needs, the user may be asked to provide a combination of:</p>
                 <ul class="list list-bullet">
-                    <li>
-                        proof that the user lives in the area
-                    </li>
-                    <li>
-                        the registration number of the vehicle to be permitted
-                    </li>
-                    <li>
-                        payment (this is to support the cost of the service and will vary across councils and potentially within service, depending on the type of vehicle, engine size, parking zone and others)
-                    </li>
+                  <li>
+                    the postcode of the area where the user wants to park
+                  </li>
+                  <li>
+                      proof that the user lives in the area
+                  </li>
+                  <li>
+                      the registration number of the vehicle to be permitted
+                  </li>
+                  <li>
+                      payment (this is to support the cost of the service and will vary across councils and potentially within service, depending on the type of vehicle, engine size, parking zone and others)
+                  </li>
                 </ul>
 
                 <h2 class="heading-medium" id="user-journey">What is the user journey?</h2>
@@ -104,9 +107,48 @@
                         </p>
                     </li>
                     <li>
-                        <h3 class="heading-small">Service start page</h3>
+                      <h3 class="heading-small">Parking start page</h3>
+                      <p>
+                        Some users may not go through the first two steps above, and arrive on the council's website with a need to park, but no knowledge that they need a permit. For this reason, it's important that the council explains they may need a permit.
+                      </p>
+                      <p>
+                        <a href="example-service/start-page">See the example service start page</a>
+                      </p>
+                    </li>
+                    <li>
+                      <h3 class="heading-small">Routing to the right boundary</h3>
+                      <p>
+                        The council needs to find out where the user wants to park so they can:
+                      </p>
+                      <ul class="list list-bullet">
+                        <li>
+                          give the permit for the right parking boundary to the user
+                        </li>
+                        <li>
+                          let the user know if there are no permits available for the area in which they want to park
+                        </li>
+                        <li>
+                          ask the user if they are a resident in the parking boundary
+                        </li>
+                      </ul>
+                      <p>
+                        This should be done at this early point in the user journey so that the user doesn't have to go through unnecessary effort.
+                      </p>
+                      <p>
+                        <a href="example-service/check-boundary">See the example page for asking users where they want to park</a>
+                      </p>
+                    </li>
+                    <li>
+                      <h3 class="heading-small">Picking the right permit type</h3>
+                      <p>
+                        Once the council knows where the user wants to park, they can tell the user about the parking boundary and ask if they are a resident of that area.
+                      </p>
+                      <a href="example-service/resident-choice">See the example service page for asking a user whether they are a resident or a visitor</a>
+                    </li>
+                    <li>
+                        <h3 class="heading-small">Resident's start page</h3>
                         <p>
-                            Now the user is in the right place, the page on the council's website should communicate:
+                            Now the user is in the right place, this page should communicate:
                         </p>
                         <ul class="list list-bullet">
                             <li>
@@ -139,7 +181,7 @@
                             </li>
                             <li>if the service differs from this pattern, include any other information the user needs to provide</li>
                         </ul>
-                        <a href="parking-permit/example-service/start-page">See the example service start page</a>
+                        <a href="example-service/resident-start">See the example service start page</a>
                     </li>
                     <li>
                         <ol class="list list-letter">
@@ -156,13 +198,13 @@
                         <p>
                             GOV.UK Verify will send the council the user's address, as known by the user's chosen identity provider. On returning from the GOV.UK Verify process, the council should ask the user to confirm whether or not this is their current address.
                         </p>
-            
-                        <a href="parking-permit/example-service/confirm-address">See the example page asking users to confirm their name and address</a>
+
+                        <a href="example-service/confirm-address">See the example page asking users to confirm their name and address</a>
                         <p>
                             If the user says the address returned is not correct, they are likely to be a new resident whose address has not been updated with their identity provider. The user should then be asked to enter their current address and warned that they must not
                             enter false information.
                         </p>
-                        <a href="parking-permit/example-service/incorrect-address">See the example page asking users to enter their current address</a>
+                        <a href="example-service/incorrect-address">See the example page asking users to enter their current address</a>
                         <p>
                             If the permit is physical, councils will get extra confidence in the address by mailing the permit to the address given. Councils should mention they'll be using the address for this purpose on the confirmation page.
                         </p>
@@ -180,7 +222,7 @@
                                     zones.
                                 </p>
                                 <p>
-                                    <a href="parking-permit/example-service/not-eligible-address">See the example page which says the user is not eligible because of their address</a>
+                                    <a href="example-service/not-eligible-address">See the example page which says the user is not eligible because of their address</a>
                                 </p>
                             </li>
                             <li>
@@ -190,7 +232,7 @@
                                     any permits currently assigned to the person or their address and issue an ineligible message if applicable.
                                 </p>
                                 <p>
-                                    <a href="parking-permit/example-service/not-eligible-permits-exceeded">See the example page which says the user is not eligible because they have exceeded the number of permits allowed</a>
+                                    <a href="example-service/not-eligible-permits-exceeded">See the example page which says the user is not eligible because they have exceeded the number of permits allowed</a>
                                 </p>
                             </li>
                             <li>
@@ -199,7 +241,7 @@
                                     If the user is eligible for multiple permits, for example visitors permits, the council should ask which type of permit the user would like to apply for.
                                 </p>
                                 <p>
-                                    <a href="parking-permit/example-service/eligible-for-many">See the example page asks the user to select which permit they wish to apply for.</a>
+                                    <a href="example-service/eligible-for-many">See the example page asks the user to select which permit they wish to apply for.</a>
                                 </p>
                             </li>
                         </ol>
@@ -213,7 +255,7 @@
                             If the price of the permit varies depending on the vehicle type, emissions, make or any other condition, the council should present information or a tool that allows correct calculation of the permit price
                         </p>
                         <p>
-                            <a href="parking-permit/example-service/enter-reg">See the example page of asking for a registration number</a>
+                            <a href="example-service/enter-reg">See the example page of asking for a registration number</a>
                         </p>
                     </li>
                     <li>
@@ -222,7 +264,7 @@
                             The fee will vary based on the fee calculation rules determined by each individual council. In some cases the permit can be issued free of charge, for example, if the resident is the first member of the household to apply.
                         </p>
                         <p>
-                            <a href="parking-permit/example-service/pre-payment">Step through the example pages of accepting payments.</a>
+                            <a href="example-service/pre-payment">Step through the example pages of accepting payments.</a>
                         </p>
                         <p>
                             Councils can accept payment via a number of channels, including checks, bank transfers or online payments.
@@ -242,7 +284,7 @@
 
                         <p>
                             The service should ask the user how they would like to receive this confirmation of payment, offering the choice of email, letter or text.
-                            <a href="/contact">See the example page on how to do this.</a>
+                            <a href="example-service/contact">See the example page on how to do this.</a>
                         </p>
                         <p>
                             In the future, councils will be able to send this confirmation using
@@ -258,7 +300,7 @@
                             You should allow users to select their prefered contact method and only contact them in this way in future.
                         </p>
                         <p>
-                            <a href="parking-permit/example-service/add_contact_details">See the example page asking users to provide their prefered contact details.</a>
+                            <a href="example-service/add_contact_details">See the example page asking users to provide their prefered contact details.</a>
                         </p>
                     </li>
                     <li>

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -112,7 +112,7 @@
                         Some users may not go through the first two steps above, and arrive on the council's website with a need to park, but no knowledge that they need a permit. For this reason, it's important that the council explains they may need a permit.
                       </p>
                       <p>
-                        <a href="example-service/start-page">See the example service start page</a>
+                        <a href="parking-permit/example-service/start-page">See the example service start page</a>
                       </p>
                     </li>
                     <li>
@@ -135,13 +135,13 @@
                         This should be done at this early point in the user journey so that the user doesn't have to go through unnecessary effort.
                       </p>
                       <p>
-                        <a href="example-service/check-boundary">See the example service page for asking users where they want to park</a>
+                        <a href="parking-permit/example-service/check-boundary">See the example service page for asking users where they want to park</a>
                       </p>
                       <p>
                         At this point the council should also check if there are permits available in the area the user wants to park in. If permits are available, move the user onto the next step. If not, the council should tell the user what the nearest boundaries with permits available are.
                       </p>
                       <p>
-                        <a href="example-service/no-permits">See the example service page for telling users there are no more permits available</a>
+                        <a href="parking-permit/example-service/no-permits">See the example service page for telling users there are no more permits available</a>
                       </p>
                     </li>
                     <li>
@@ -149,7 +149,7 @@
                       <p>
                         Once the council knows where the user wants to park, they can tell the user about the parking boundary and ask if they are a resident of that area.
                       </p>
-                      <a href="example-service/resident-choice">See the example service page for asking a user whether they are a resident or a visitor</a>
+                      <a href="parking-permit/example-service/resident-choice">See the example service page for asking a user whether they are a resident or a visitor</a>
                     </li>
                     <li>
                         <h3 class="heading-small">Resident's start page</h3>
@@ -187,7 +187,7 @@
                             </li>
                             <li>if the service differs from this pattern, include any other information the user needs to provide</li>
                         </ul>
-                        <a href="example-service/resident-start">See the example service start page</a>
+                        <a href="parking-permit/example-service/resident-start">See the example service start page</a>
                     </li>
                     <li>
                         <ol class="list list-letter">
@@ -205,12 +205,12 @@
                             GOV.UK Verify will send the council the user's address, as known by the user's chosen identity provider. On returning from the GOV.UK Verify process, the council should ask the user to confirm whether or not this is their current address.
                         </p>
 
-                        <a href="example-service/confirm-address">See the example page asking users to confirm their name and address</a>
+                        <a href="parking-permit/example-service/confirm-address">See the example page asking users to confirm their name and address</a>
                         <p>
                             If the user says the address returned is not correct, they are likely to be a new resident whose address has not been updated with their identity provider. The user should then be asked to enter their current address and warned that they must not
                             enter false information.
                         </p>
-                        <a href="example-service/incorrect-address">See the example page asking users to enter their current address</a>
+                        <a href="parking-permit/example-service/incorrect-address">See the example page asking users to enter their current address</a>
                         <p>
                             If the permit is physical, councils will get extra confidence in the address by mailing the permit to the address given. Councils should mention they'll be using the address for this purpose on the confirmation page.
                         </p>
@@ -228,7 +228,7 @@
                                     zones.
                                 </p>
                                 <p>
-                                    <a href="example-service/not-eligible-address">See the example page which says the user is not eligible because of their address</a>
+                                    <a href="parking-permit/example-service/not-eligible-address">See the example page which says the user is not eligible because of their address</a>
                                 </p>
                             </li>
                             <li>
@@ -238,7 +238,7 @@
                                     any permits currently assigned to the person or their address and issue an ineligible message if applicable.
                                 </p>
                                 <p>
-                                    <a href="example-service/not-eligible-permits-exceeded">See the example page which says the user is not eligible because they have exceeded the number of permits allowed</a>
+                                    <a href="parking-permit/example-service/not-eligible-permits-exceeded">See the example page which says the user is not eligible because they have exceeded the number of permits allowed</a>
                                 </p>
                             </li>
                             <li>
@@ -247,7 +247,7 @@
                                     If the user is eligible for multiple permits, for example visitors permits, the council should ask which type of permit the user would like to apply for.
                                 </p>
                                 <p>
-                                    <a href="example-service/eligible-for-many">See the example page asks the user to select which permit they wish to apply for.</a>
+                                    <a href="parking-permit/example-service/eligible-for-many">See the example page asks the user to select which permit they wish to apply for.</a>
                                 </p>
                             </li>
                         </ol>
@@ -261,7 +261,7 @@
                             If the price of the permit varies depending on the vehicle type, emissions, make or any other condition, the council should present information or a tool that allows correct calculation of the permit price
                         </p>
                         <p>
-                            <a href="example-service/enter-reg">See the example page of asking for a registration number</a>
+                            <a href="parking-permit/example-service/enter-reg">See the example page of asking for a registration number</a>
                         </p>
                     </li>
                     <li>
@@ -270,7 +270,7 @@
                             The fee will vary based on the fee calculation rules determined by each individual council. In some cases the permit can be issued free of charge, for example, if the resident is the first member of the household to apply.
                         </p>
                         <p>
-                            <a href="example-service/pre-payment">Step through the example pages of accepting payments.</a>
+                            <a href="parking-permit/example-service/pre-payment">Step through the example pages of accepting payments.</a>
                         </p>
                         <p>
                             Councils can accept payment via a number of channels, including checks, bank transfers or online payments.
@@ -290,7 +290,7 @@
 
                         <p>
                             The service should ask the user how they would like to receive this confirmation of payment, offering the choice of email, letter or text.
-                            <a href="example-service/contact">See the example page on how to do this.</a>
+                            <a href="parking-permit/example-service/contact">See the example page on how to do this.</a>
                         </p>
                         <p>
                             In the future, councils will be able to send this confirmation using
@@ -306,7 +306,7 @@
                             You should allow users to select their prefered contact method and only contact them in this way in future.
                         </p>
                         <p>
-                            <a href="example-service/add_contact_details">See the example page asking users to provide their prefered contact details.</a>
+                            <a href="parking-permit/example-service/add_contact_details">See the example page asking users to provide their prefered contact details.</a>
                         </p>
                     </li>
                     <li>

--- a/app/views/service-patterns/parking-permit/index.html
+++ b/app/views/service-patterns/parking-permit/index.html
@@ -135,7 +135,13 @@
                         This should be done at this early point in the user journey so that the user doesn't have to go through unnecessary effort.
                       </p>
                       <p>
-                        <a href="example-service/check-boundary">See the example page for asking users where they want to park</a>
+                        <a href="example-service/check-boundary">See the example service page for asking users where they want to park</a>
+                      </p>
+                      <p>
+                        At this point the council should also check if there are permits available in the area the user wants to park in. If permits are available, move the user onto the next step. If not, the council should tell the user what the nearest boundaries with permits available are.
+                      </p>
+                      <p>
+                        <a href="example-service/no-permits">See the example service page for telling users there are no more permits available</a>
                       </p>
                     </li>
                     <li>


### PR DESCRIPTION
Addresses #146. 

When I started thinking about where in the user journey a permits availability checker should go, I realised it should come right up front, and that there is a need to work which boundary the user needs to park in at this point as well. So I've added both, and added the choice of residents/visitors in there in a place that I think makes sense as well.

This effectively creates a "pre-start page", or as I've called it in the pattern text, a "parking start page" which comes before the "resident's start page".

**Pattern text**
<img width="755" alt="screen shot 2017-03-10 at 14 02 00" src="https://cloud.githubusercontent.com/assets/4106955/23797947/34599f72-059a-11e7-85b1-4da5322690fa.png">
<img width="789" alt="screen shot 2017-03-10 at 14 02 15" src="https://cloud.githubusercontent.com/assets/4106955/23797948/34597696-059a-11e7-8082-b64440147f88.png">

**Prototype**
<img width="1440" alt="screen shot 2017-03-10 at 13 59 39" src="https://cloud.githubusercontent.com/assets/4106955/23797869/d5d74c4c-0599-11e7-89ad-4dff372ade71.png">
<img width="1440" alt="screen shot 2017-03-10 at 14 00 00" src="https://cloud.githubusercontent.com/assets/4106955/23797883/e81e256a-0599-11e7-85b0-f93f1caedec0.png">
<img width="1440" alt="screen shot 2017-03-10 at 14 00 33" src="https://cloud.githubusercontent.com/assets/4106955/23797900/f9afeba6-0599-11e7-97db-b826aafae513.png">
<img width="1440" alt="screen shot 2017-03-10 at 14 01 22" src="https://cloud.githubusercontent.com/assets/4106955/23797921/0fb731f2-059a-11e7-89da-fba351b9ead3.png">
