### PR TITLE
Improvements to parking permits start page

### DIFF
--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -14,6 +14,9 @@
     These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
   </p>
   <p>
+    Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}} depending on your vehicle type and how many other other permits have been bought by your household.
+  </p>
+  <p>
     If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.
   </p>
   <a class="button button-start" href="prove-identity" role="button">Apply for a resident's parking permit</a>
@@ -37,9 +40,6 @@
       </li>
       <li>
         Permits can be bought for 6 months or for 12 months.
-      </li>
-       <li>
-         Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}} depending on your vehicle type and how many other other permits have been bought by your household.
       </li>
       {% if council.permitWait < 1 %}
       <li>

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -1,7 +1,7 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for a parking permit" %}
-{% set pageTitle = "Apply for a resident's parking permit" %}
+{% set pageTitle = "Apply for a resident's parking permit in " + council.parkingBoundary %}
 
 {% block content %}
 
@@ -13,6 +13,22 @@
   <p>
     These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
   </p>
+  <p>
+    If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.
+  </p>
+  <a class="button button-start" href="prove-identity" role="button">Apply for a resident's parking permit</a>
+
+  <p>
+    This service is for new applications. You can also:
+  </p>
+  <ul class="list list-bullet">
+    <li>
+      <a href="#">replace a lost or stolen parking permit.</a>
+    </li>
+    <li>
+      <a href="#">renew an expired parking permit.</a>
+    </li>
+  </ul>
 
   <h2 class="heading-medium">About this service</h2>
     <ul class="list list-bullet">
@@ -42,7 +58,6 @@
       </li>
     </ul>
 
-  <a class="button button-start" href="prove-identity" role="button">Apply online now</a>
 
   <p>
     If you need assistance using the online service, <a href="#">contact {{ council.name }}</a>.


### PR DESCRIPTION
Fixes #215 - Link to renewals
Fixes #216  - Link to replacements

Addresses #225 - Moves cost info higher up the page
Addresses #226 - Specifies boundary in header (this will be really different for local versions though)
Addresses 

Trying to be mindful of #227, although that issue might want rewording really... It's more of an insight than an addressable issue.

Also this design is more consistent with the latest design for Concessionary Travel, documented in PR #247.

## Before

![screenshot-verify-local-patterns herokuapp com 2017-03-22 17-08-49](https://cloud.githubusercontent.com/assets/4106955/24210843/3e6c7d04-0f22-11e7-92cd-d18936f9b29a.png)

## After

![screenshot-localhost-3000 2017-03-22 17-09-40](https://cloud.githubusercontent.com/assets/4106955/24210885/5fa9a8fc-0f22-11e7-9b23-116241317f8a.png)

