### PR TITLE
Improve and make consistent the success pages

### DIFF
--- a/app/views/common-content/verify-reuse.html
+++ b/app/views/common-content/verify-reuse.html
@@ -1,0 +1,19 @@
+<h2 class="heading-medium">About your GOV.UK Verify account</h2>
+
+<p>
+  You can also reuse your GOV.UK Verify account on other government services such as:
+</p>
+
+<ul class="list-bullet list">
+  <li><a href="https://www.gov.uk/claim-redundancy">claim your redundancy payment and monies owed</a></li>
+  <li><a href="https://www.gov.uk/check-state-pension">check your State Pension</a></li>
+  <li><a href="https://www.gov.uk/renew-medical-driving-licence">renew your short-term medical driving license</a></li>
+  <li><a href="https://www.gov.uk/help-friends-family-tax">help friends and family with their tax</a></li>
+  <li><a href="https://www.gov.uk/report-driving-medical-condition">report a medical condition that affects your driving</a></li>
+  <li><a href="https://www.gov.uk/view-driving-licence">view or share your driving licence information</a></li>
+  <li><a href="https://www.universal-credit.service.gov.uk/sign-in">complete your claim or access your Universal Credit account</a></li>
+  <li><a href="https://www.gov.uk/update-company-car-details">check or update your company car tax</a></li>
+  <li><a href="https://www.gov.uk/check-income-tax-current-year">check your income tax for the current year</a></li>
+  <li><a href="https://www.gov.uk/log-in-file-self-assessment-tax-return/if-youre-already-registered">complete your Self Assessment</a></li>
+  <li><a href="https://www.gov.uk/personal-tax-account">sign in to your personal tax account</a></li>
+</ul>

--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -12,14 +12,20 @@
       </p>
     </div>
 
-  <p><a href="#">Request a confirmation email.</a></p>
-
   <div class="column-two-thirds">
     <p>
-     {% if skip_verify == true %} As long as your photo, proof of address and proof of age pass our manual checks, we'll send you your bus pass within 5 days. {% else %} As long as your photo passes our manual checks, we'll send you your bus pass within 5 days.{% endif %}
+      You'll receive a confirmation email and text with this reference number.
     </p>
     <p>
-      We'll use this address:
+      You'll also receive another message within 3 days when your bus pass is on it's away.
+    </p>
+
+  <!-- <p><a href="#">Request a confirmation email.</a></p> -->
+    <p>
+     {% if skip_verify == true %} As long as your photo, proof of address and proof of age pass our manual checks, we'll send you your bus pass within 10 days. {% else %} As long as your photo passes our manual checks, we'll send you your bus pass within 5 days.{% endif %}
+    </p>
+    <p>
+      We'll send your bus pass to this address:
     </p>
     <div class="panel panel-border-wide">
       <p>
@@ -35,9 +41,6 @@
 
     <ul class="list list-bullet">
       <li>
-        Your pass will expire in 5 years. If you'd like to receive a notification when it's time to renew your bus pass, <a href="/service-patterns/concessionary-travel/example-service/renewal-notification">sign up for a renewal notification</a>.
-      </li>
-      <li>
         When travelling, you must have your pass with you and present it to the driver to get your free travel.
       </li>
       <li>
@@ -46,11 +49,13 @@
       <li>
         You are not permitted to hold more than one pass.
       </li>
+      <li>
+        Your pass will expire in 5 years. You've signed up to receive a text and email when it's time to renew your pass.
+        <!-- <a href="/service-patterns/concessionary-travel/example-service/renewal-notification">sign up for a renewal notification</a>. -->
+      </li>
     </ul>
 
-    <p>
-      Whilst we process your application, we can send you notifications of it's progress. <a href="/service-patterns/concessionary-travel/example-service/add_contact_details">Sign up for a progress notifications</a>.
-    </p>
+    {% include "common-content/verify-reuse.html" %}
 
     </div>
 

--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -37,7 +37,7 @@
       <a href="#">Provide a different address</a>
     </div>
 
-    <h2 class="heading-medium">About your pass</h2>
+    <h2 class="heading-medium">About your older person's bus pass</h2>
 
     <ul class="list list-bullet">
       <li>

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -5,6 +5,13 @@
 
 {% block content %}
 
+<div class="govuk-box-highlight">
+  <p>
+    Your reference number is <br>
+    <strong class="heading-large">HDJ2123F</strong>
+  </p>
+</div>
+
   <div class="column-two-thirds">
     {% if contactChoice == 'Email' %}
     <p>You should receive a confirmation email within the next minute.</p>
@@ -25,7 +32,7 @@
       You can expect your permit to arrive within 5 working days.
     </p>
     <p>
-      We'll send it to this address:
+      We'll send your parking permit to this address:
     </p>
     <div class="panel panel-border-wide">
       <p>
@@ -40,7 +47,23 @@
       In the mean time, you can print this <a href="#">temporary permit</a> and display it in your car window.
     </p>
     {% endif %}
+
+    <h2 class="heading-medium">About your parking permit</h2>
+
+    <ul class="list list-bullet">
+      <li>
+        Your parking permit allows you to park in {{council.parkingBoundary}} at any time.
+      </li>
+      <li>
+        Your permit expires in 12 months. You've signed up to receive an email and text when your permit expires.
+      </li>
+    </ul>
+
+    {% include "common-content/verify-reuse.html" %}
+
   </div>
+
+
 
 
 </main>


### PR DESCRIPTION
 - Added the big blue banner for parking permits, because of #237.

 - Added a list of services that users can reuse Verify on. This probably won't be the final design (it's quite a long list of services, and would grow over time) - but I'd like to see this in research, particularly see which services, if any, users are interested in, and really whether or not they find this info useful. This aims to address #191 and #190 to some extent.

 - Also includes minor content changes to address #189.

## Before

### CT

![screenshot-verify-local-patterns herokuapp com 2017-03-24 10-37-19](https://cloud.githubusercontent.com/assets/4106955/24290712/e5f9a054-107d-11e7-8cc5-b307c6edebb2.png)

### PP

![screen shot 2017-03-24 at 10 37 55](https://cloud.githubusercontent.com/assets/4106955/24290727/f8cec358-107d-11e7-9dcb-02e2883e02b7.png)


## After

### CT

![screenshot-localhost-3000 2017-03-24 10-38-33](https://cloud.githubusercontent.com/assets/4106955/24290753/0e22f8aa-107e-11e7-8daa-7eec43c86d8c.png)

### PP 

![screenshot-localhost-3000 2017-03-24 10-39-07](https://cloud.githubusercontent.com/assets/4106955/24290789/2a7dbb70-107e-11e7-8342-2fcc56194174.png)


