### PR TITLE
add ability to add boundary link

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -6,7 +6,8 @@
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
     "permitWait": 5,
-    "string": "argleton"
+    "string": "argleton",
+    "boundaryLink": "https://en.wikipedia.org/wiki/Argleton"
   },
   {
     "name": "Buckinghamshire County Council",

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -8,7 +8,7 @@
 <div class="column-two-thirds">
 
   <p>
-    Residents of {{council.parkingBoundary}} can buy resident's parking permits.
+    Residents of {% if council.boundaryLink %}<a href="{{council.boundaryLink}}">{{council.parkingBoundary}}</a>{% else %} {{council.parkingBoundary}}{% endif %} can buy resident's parking permits.
   </p>
   <p>
     These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.


### PR DESCRIPTION
Displays the parking boundary text as a link if the council has added a `boundaryLink` option in `councils.json`. 

Aims to address #259.

## Before

<img width="1119" alt="screen shot 2017-03-28 at 11 41 22" src="https://cloud.githubusercontent.com/assets/4106955/24401267/9803abe8-13ab-11e7-9ef5-219d07cf63de.png">

## After

<img width="1192" alt="screen shot 2017-03-28 at 11 42 19" src="https://cloud.githubusercontent.com/assets/4106955/24401279/a2f1b054-13ab-11e7-8538-b9d15947b968.png">

