### PR TITLE
Remove references to permit price being calculated from vehicle details

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -6,7 +6,8 @@
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
     "permitWait": 5,
-    "string": "argleton"
+    "string": "argleton",
+    "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price."
   },
   {
     "name": "Buckinghamshire County Council",

--- a/app/councils.json
+++ b/app/councils.json
@@ -7,7 +7,7 @@
     "permitsCosts": [51, 81, 153, 153],
     "permitWait": 5,
     "string": "argleton",
-    "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price.",
+    "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price.</p><p>You can park anywhere within the boundary, at any time, once you have a permit.",
     "boundaryLink": "https://en.wikipedia.org/wiki/Argleton"
   },
   {

--- a/app/views/service-patterns/parking-permit/example-service/eligible.html
+++ b/app/views/service-patterns/parking-permit/example-service/eligible.html
@@ -8,7 +8,7 @@
 <div class="column-two-thirds">
 
   <p>
-    The permit will allow you to park in the city centre 24 hours a day.
+    The permit will allow you to park in {{council.parkingBoundary}} 24 hours a day.
   </p>
 
   <a class="button" role="button" href="enter-reg">Next</a>

--- a/app/views/service-patterns/parking-permit/example-service/enter-reg.html
+++ b/app/views/service-patterns/parking-permit/example-service/enter-reg.html
@@ -7,6 +7,14 @@
 
 <div class="column-two-thirds">
 
+  {% if council.customPriceLogic %}
+  
+  <p>
+    We need your vehicle's registration number to associate your permit with your vehicle
+  </p>
+
+  {% else %}
+
   <p>
     We need your vehicle's registration number to
   </p>
@@ -19,6 +27,7 @@
       associate your permit with your vehicle
     </li>
   </ul>
+  {% endif %}
 
   <div class="form-group">
       <form method="post">

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -7,6 +7,8 @@
 
 <div class="column-two-thirds">
 
+{% if not council.customPriceLogic %}
+
 <p>
   We've received these details from DVLA:
 </p>
@@ -45,6 +47,8 @@
     </th>
   </tr>
 </table>
+
+{% endif %}
 
 {% if(council.permitsCosts[0] > 0) %}
 {% set halfCost = council.permitsCosts[0] / 2 %}

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -56,7 +56,7 @@
 {% endif %}
 
 <p>
-  Based on this information, your parking permit options are:
+  {{ "Based on this information, y" if not council.customPriceLogic else "Y" }}our parking permit options are:
 </p>
 
 <form action="permit-details" method="post">

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -14,7 +14,11 @@
     These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
   </p>
   <p>
+  {% if council.customPriceLogic %}
+    {{council.customPriceLogic | safe}}
+  {% else %}
     Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+  {% endif %}
   </p>
   <p>
     If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -10,16 +10,18 @@
   <p>
     Residents of {% if council.boundaryLink %}<a href="{{council.boundaryLink}}">{{council.parkingBoundary}}</a>{% else %} {{council.parkingBoundary}}{% endif %} can buy resident's parking permits.
   </p>
-  <p>
-    These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
-  </p>
-  <p>
   {% if council.customPriceLogic %}
-    {{council.customPriceLogic | safe}}
+    <p>
+      {{council.customPriceLogic | safe}}
+    </p>
   {% else %}
-    Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+    <p>
+      These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
+    </p>
+    <p>
+      Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+    </p>
   {% endif %}
-  </p>
   <p>
     If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.
   </p>


### PR DESCRIPTION
Addresses #266 to give the option of a custom price logic. Will do some more work around this once we have councils fill in what their pricing logic is.

You can switch between the Before/After states on this PR by removing the `customPriceLogic` option for Argleton in `councils.json`, or by changing to any other council which doesn't have that variable on `/council-picker`.

## Before
<img width="1126" alt="screen shot 2017-03-28 at 15 18 02" src="https://cloud.githubusercontent.com/assets/4106955/24410227/71a626dc-13ca-11e7-8750-599d61028920.png">

<img width="1129" alt="screen shot 2017-03-28 at 15 23 37" src="https://cloud.githubusercontent.com/assets/4106955/24410262/8acbe584-13ca-11e7-8e08-50a0c0186b0e.png">

<img width="978" alt="screen shot 2017-03-28 at 15 24 03" src="https://cloud.githubusercontent.com/assets/4106955/24410291/98525792-13ca-11e7-89da-dfd22065d862.png">

## After

<img width="1110" alt="screen shot 2017-03-28 at 15 24 32" src="https://cloud.githubusercontent.com/assets/4106955/24410308/aa0b2f5e-13ca-11e7-9649-72ae53f91225.png">
<img width="1083" alt="screen shot 2017-03-28 at 15 25 04" src="https://cloud.githubusercontent.com/assets/4106955/24410343/bda219c4-13ca-11e7-8d7c-8ec74396512b.png">
<img width="1008" alt="screen shot 2017-03-28 at 15 25 24" src="https://cloud.githubusercontent.com/assets/4106955/24410360/c98ef0ea-13ca-11e7-8d1e-6e027f8484f5.png">
