### PR TITLE
Option for councils with only 1 price of permit

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -6,7 +6,8 @@
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
     "permitWait": 5,
-    "string": "argleton"
+    "string": "argleton",
+    "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price."
   },
   {
     "name": "Buckinghamshire County Council",

--- a/app/councils.json
+++ b/app/councils.json
@@ -7,7 +7,7 @@
     "permitsCosts": [51, 81, 153, 153],
     "permitWait": 5,
     "string": "argleton",
-    "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price.",
+    "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price.</p><p>You can park anywhere within the boundary, at any time, once you have a permit.",
     "boundaryLink": "https://en.wikipedia.org/wiki/Argleton"
   },
   {

--- a/app/views/service-patterns/parking-permit/example-service/eligible.html
+++ b/app/views/service-patterns/parking-permit/example-service/eligible.html
@@ -8,7 +8,7 @@
 <div class="column-two-thirds">
 
   <p>
-    The permit will allow you to park in the city centre 24 hours a day.
+    The permit will allow you to park in {{council.parkingBoundary}} 24 hours a day.
   </p>
 
   <a class="button" role="button" href="enter-reg">Next</a>

--- a/app/views/service-patterns/parking-permit/example-service/enter-reg.html
+++ b/app/views/service-patterns/parking-permit/example-service/enter-reg.html
@@ -7,6 +7,14 @@
 
 <div class="column-two-thirds">
 
+  {% if council.customPriceLogic %}
+  
+  <p>
+    We need your vehicle's registration number to associate your permit with your vehicle
+  </p>
+
+  {% else %}
+
   <p>
     We need your vehicle's registration number to
   </p>
@@ -19,6 +27,7 @@
       associate your permit with your vehicle
     </li>
   </ul>
+  {% endif %}
 
   <div class="form-group">
       <form method="post">

--- a/app/views/service-patterns/parking-permit/example-service/enter-reg.html
+++ b/app/views/service-patterns/parking-permit/example-service/enter-reg.html
@@ -18,14 +18,6 @@
 
   {% else %}
 
-  {% if council.customPriceLogic %}
-  
-  <p>
-    We need your vehicle's registration number to associate your permit with your vehicle
-  </p>
-
-  {% else %}
-
   <p>
     We need your vehicle's registration number to
   </p>

--- a/app/views/service-patterns/parking-permit/example-service/enter-reg.html
+++ b/app/views/service-patterns/parking-permit/example-service/enter-reg.html
@@ -6,9 +6,12 @@
 {% block content %}
 
 <div class="column-two-thirds">
+  {% if council.permitsCosts[0] - council.permitsCosts[council.permitsCosts.length-1] == 0 %}
+  {% set singleCost = council.permitsCosts[0] %}
+  {% endif %}
 
-  {% if council.customPriceLogic %}
-  
+  {% if council.customPriceLogic or singleCost %}
+
   <p>
     We need your vehicle's registration number to associate your permit with your vehicle
   </p>

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -7,57 +7,63 @@
 
 <div class="column-two-thirds">
 
-{% if not council.customPriceLogic %}
+  {% if council.permitsCosts[0] - council.permitsCosts[council.permitsCosts.length-1] == 0 %}
+  {% set singleCost = council.permitsCosts[0] %}
+  {% endif %}
 
-<p>
-  We've received these details from DVLA:
-</p>
+  {% if council.customPriceLogic or singleCost %}
+  
+    <p>
+      Your parking permit options are:
+    </p>
 
-<table>
-  <tr>
-    <th>
-      Registration number
-    </th>
-    <th>
-      KS53 UTW
-    </th>
-  </tr>
-  <tr>
-    <th>
-      Vehicle make
-    </th>
-    <th>
-      VOLKSWAGEN
-    </th>
-  </tr>
-  <tr>
-    <th>
-      Cylinder capacity (cc)
-    </th>
-    <th>
-      1984cc
-    </th>
-  </tr>
-  <tr>
-    <th>
-      CO₂ emissions
-    </th>
-    <th>
-      192 g/km
-    </th>
-  </tr>
-</table>
+  {% else %}
 
-{% endif %}
+    <p>
+      We've received these details from DVLA:
+    </p>
 
+    <table>
+      <tr>
+        <th>
+          Registration number
+        </th>
+        <th>
+          KS53 UTW
+        </th>
+      </tr>
+      <tr>
+        <th>
+          Vehicle make
+        </th>
+        <th>
+          VOLKSWAGEN
+        </th>
+      </tr>
+      <tr>
+        <th>
+          Cylinder capacity (cc)
+        </th>
+        <th>
+          1984cc
+        </th>
+      </tr>
+      <tr>
+        <th>
+          CO₂ emissions
+        </th>
+        <th>
+          192 g/km
+        </th>
+      </tr>
+    </table>
 
-{% if council.permitsCosts[0] - council.permitsCosts[council.permitsCosts.length-1] == 0 %}
-{% set singleCost = council.permitsCosts[0] %}
-{% endif %}
+    <p>
+      Based on this information, your parking permit options are:
+    </p>
 
-<p>
-  {% if council.customPriceLogic or singleCost %}Your{% else %}Based on this information, your{% endif %} parking permit options are:
-</p>
+  {% endif %}
+
 
 {% if(council.permitsCosts[0] > 0) %}
 {% set halfCost = council.permitsCosts[0] / 2 %}

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -7,6 +7,8 @@
 
 <div class="column-two-thirds">
 
+{% if not council.customPriceLogic %}
+
 <p>
   We've received these details from DVLA:
 </p>
@@ -45,6 +47,8 @@
     </th>
   </tr>
 </table>
+
+{% endif %}
 
 {% if(council.permitsCosts[0] > 0) %}
 {% set halfCost = council.permitsCosts[0] / 2 %}

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -56,7 +56,7 @@
 {% endif %}
 
 <p>
-  Based on this information, your parking permit options are:
+  {{ "Based on this information, y" if not council.customPriceLogic else "Y" }}our parking permit options are:
 </p>
 
 <form action="permit-details" method="post">

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -46,6 +46,14 @@
   </tr>
 </table>
 
+{% if council.permitsCosts[0] - council.permitsCosts[council.permitsCosts.length-1] == 0 %}
+{% set singleCost = council.permitsCosts[0] %}
+{% endif %}
+
+<p>
+  {% if council.customPriceLogic or singleCost %}Your{% else %}Based on this information, your{% endif %} parking permit options are:
+</p>
+
 {% if(council.permitsCosts[0] > 0) %}
 {% set halfCost = council.permitsCosts[0] / 2 %}
 {% set halfCost = halfCost.toFixed(2) %}
@@ -54,10 +62,6 @@
 {% set halfCost = 0 %}
 {% set fullCost = 0 %}
 {% endif %}
-
-<p>
-  {{ "Based on this information, y" if not council.customPriceLogic else "Y" }}our parking permit options are:
-</p>
 
 <form action="permit-details" method="post">
   <div class="form-group">

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -14,7 +14,11 @@
     These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
   </p>
   <p>
+  {% if council.customPriceLogic %}
+    {{council.customPriceLogic | safe}}
+  {% else %}
     Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+  {% endif %}
   </p>
   <p>
     If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -13,8 +13,11 @@
   <p>
     These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
   </p>
+  {% if council.permitsCosts[0] - council.permitsCosts[council.permitsCosts.length-1] == 0 %}
+  {% set singleCost = council.permitsCosts[0] %}
+  {% endif %}
   <p>
-    Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+    Resident's parking permits cost {% if singleCost %}£{{singleCost}}.{% else %}between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[council.permitsCosts.length-1]}}, depending on your vehicle type and how many other other permits have been bought by your household.{% endif %}
   </p>
   <p>
     If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -10,16 +10,18 @@
   <p>
     Residents of {% if council.boundaryLink %}<a href="{{council.boundaryLink}}">{{council.parkingBoundary}}</a>{% else %} {{council.parkingBoundary}}{% endif %} can buy resident's parking permits.
   </p>
-  <p>
-    These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
-  </p>
-  <p>
   {% if council.customPriceLogic %}
-    {{council.customPriceLogic | safe}}
+    <p>
+      {{council.customPriceLogic | safe}}
+    </p>
   {% else %}
-    Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+    <p>
+      These permits allow you to park anywhere within {{council.parkingBoundary}} 24 hours a day, 7 days a week.
+    </p>
+    <p>
+      Permits cost between £{{council.permitsCosts[0]}} and £{{council.permitsCosts[3]}}, depending on your vehicle type and how many other other permits have been bought by your household.
+    </p>
   {% endif %}
-  </p>
   <p>
     If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.
   </p>


### PR DESCRIPTION
**This PR is dependent on #271 - Don't merge this until that one's done.**

(I made the branch dependant on #271 because there's so much overlap, so better to fix all the conflicts and see what they both look like together.)

---

This fixes #254 - Deals with single price councils.

Bucks submitted their prices as a single item, whereas Northumberland submitted their prices as an array of 4 of the same number. Neither of these are wrong and future councils might do either, so the logic I've written (`if council.permitsCosts[0] - council.permitsCosts[council.permitsCosts.length-1] == 0`) takes the first cost and subtracts the last cost. If the answer is 0, then we know there's only one cost.

I've also moved the cost information up above the boundary information as people said in research that they wanted to know that quicker, and it makes it more consistent across the councils.


## Before
<img width="1133" alt="screen shot 2017-03-29 at 11 05 36" src="https://cloud.githubusercontent.com/assets/4106955/24449596/aae65e4e-146f-11e7-860d-f4aa4aa810da.png">

## After
<img width="1110" alt="screen shot 2017-03-29 at 11 09 05" src="https://cloud.githubusercontent.com/assets/4106955/24449753/43475530-1470-11e7-9648-8c874bfc80c0.png">
<img width="1103" alt="screen shot 2017-03-29 at 11 10 15" src="https://cloud.githubusercontent.com/assets/4106955/24449770/4f80fa36-1470-11e7-881f-e6c4d31ae2c2.png">
<img width="1254" alt="screen shot 2017-03-29 at 11 10 47" src="https://cloud.githubusercontent.com/assets/4106955/24449799/63c76ea8-1470-11e7-9ce3-3f7064c9819c.png">
<img width="1381" alt="screen shot 2017-03-29 at 11 11 10" src="https://cloud.githubusercontent.com/assets/4106955/24449814/712fd4c2-1470-11e7-97d1-8fb4e8b361f3.png">
<img width="1139" alt="screen shot 2017-03-29 at 11 11 36" src="https://cloud.githubusercontent.com/assets/4106955/24449838/80320828-1470-11e7-9e76-0b2d759867c3.png">
