### PR TITLE
option to remove temporary permits

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -6,6 +6,7 @@
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
     "permitWait": 5,
+    "tempPermit":true,
     "string": "argleton",
     "customPriceLogic": "Permits cost between £51 and £153 depending on where you want to park. You'll need to <a href='#'>check the boundaries</a> to find your price.</p><p>You can park anywhere within the boundary, at any time, once you have a permit.",
     "boundaryLink": "https://en.wikipedia.org/wiki/Argleton"
@@ -17,6 +18,7 @@
     "permitMax": "2",
     "permitsCosts": [52],
     "permitWait": 0,
+    "tempPermit":true,
     "string": "buckinghamshire"
   },
   {
@@ -26,6 +28,7 @@
     "permitMax": "unlimited",
     "permitsCosts": [51,61,71,120],
     "permitWait": 5,
+    "tempPermit":true,
     "string" : "cambridgeshire"
   },
   {
@@ -35,6 +38,7 @@
     "permitMax": "two",
     "permitsCosts": [130,130,130,130],
     "permitWait": 0,
+    "tempPermit":true,
     "string" : "northumberland"
   },
   {
@@ -44,6 +48,7 @@
     "permitMax": "five",
     "permitsCosts": [0, 20, 40, 60],
     "permitWait": 3,
+    "tempPermit":true,
     "string" : "sunderland"
     },
   {
@@ -53,6 +58,7 @@
     "permitMax": "sixty seven",
     "permitsCosts": [67, 77, 100, 100],
     "permitWait": 0,
+    "tempPermit":true,
     "string" : "unbranded"
   }
 ]

--- a/app/views/service-patterns/parking-permit/example-service/resident-start.html
+++ b/app/views/service-patterns/parking-permit/example-service/resident-start.html
@@ -53,7 +53,10 @@
       </li>
       {% else %}
       <li>
-        Your permit will take {{council.permitWait}} working days to arrive. While you wait, you'll need to use a temporary permit which we will email to you.
+        Your permit will take {{council.permitWait}} working days to arrive. 
+        {% if council.tempPermit == true %}
+        While you wait, you'll need to use a temporary permit which we will email to you.
+        {% endif %}
       </li>
       {% endif %}
       <li>

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -43,9 +43,12 @@
       </p>
       <a href="#">Provide a different address</a>
     </div>
+    {% if council.tempPermit == true %}
     <p>
       In the mean time, you can print this <a href="#">temporary permit</a> and display it in your car window.
     </p>
+    {% endif %}
+    
     {% endif %}
 
     <h2 class="heading-medium">About your parking permit</h2>


### PR DESCRIPTION
If set to false will hide messages about temporary permits in resident-start.html and success.html

This addresses issue: #268