### PR TITLE
Option for no online pay

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -5,7 +5,7 @@
     "parkingBoundary": "Argleton city centre",
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
-    "payOnline":false,
+    "payOnline":true,
     "permitWait": 5,
     "tempPermit":true,
     "string": "argleton",

--- a/app/councils.json
+++ b/app/councils.json
@@ -5,6 +5,7 @@
     "parkingBoundary": "Argleton city centre",
     "permitMax": "four",
     "permitsCosts": [51, 81, 153, 153],
+    "payOnline":false,
     "permitWait": 5,
     "tempPermit":true,
     "string": "argleton",
@@ -17,6 +18,7 @@
     "parkingBoundary": "Buckinghamshire",
     "permitMax": "2",
     "permitsCosts": [52],
+    "payOnline":true,
     "permitWait": 0,
     "tempPermit":true,
     "string": "buckinghamshire"
@@ -27,6 +29,7 @@
     "parkingBoundary": "Cambridgeshire city centre",
     "permitMax": "unlimited",
     "permitsCosts": [51,61,71,120],
+    "payOnline":true,
     "permitWait": 5,
     "tempPermit":true,
     "string" : "cambridgeshire"
@@ -37,6 +40,7 @@
     "parkingBoundary" : "Northumberland Council",
     "permitMax": "two",
     "permitsCosts": [130,130,130,130],
+    "payOnline":true,
     "permitWait": 0,
     "tempPermit":true,
     "string" : "northumberland"
@@ -47,6 +51,7 @@
     "parkingBoundary": "Sunderland city centre",
     "permitMax": "five",
     "permitsCosts": [0, 20, 40, 60],
+    "payOnline":true,
     "permitWait": 3,
     "tempPermit":true,
     "string" : "sunderland"
@@ -57,6 +62,7 @@
     "parkingBoundary" : "Unbrandedland city",
     "permitMax": "sixty seven",
     "permitsCosts": [67, 77, 100, 100],
+    "payOnline":true,
     "permitWait": 0,
     "tempPermit":true,
     "string" : "unbranded"

--- a/app/views/service-patterns/parking-permit/example-service/pre-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/pre-payment.html
@@ -1,15 +1,29 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Proceed to payment" %}
+{% set pageTitle = "Paying for your permit" %}
 
 {% block content %}
 
 <div class="column-two-thirds">
 
-  <p>
-    You're about to pay for:
-  </p>
+
+  
+    {% if council.payOnline %}
+      <p>
+        You're about to pay for:
+      </p>
+    {% else %}
+      <p>
+        Once we have processed and approved your application, we will contact you for payment. You will be able to pay over the phone by either a debit/credit card (no service charges apply).
+      </p>
+      
+      <p>
+        You will need to pay for:
+      </p>
+      
+    {% endif %}
+  
 
   <table>
     <tr>
@@ -54,9 +68,11 @@
       </th>
     </tr>
   </table>
-
-   <a class="button" role="button" href="choose-payment">Next</a>
-
+  {% if council.payOnline %}
+    <a class="button" role="button" href="choose-payment">Next</a>
+  {% else %}
+    <a class="button" role="button" href="contact-reference">Next</a>
+  {% endif %}
 </main>
 
 {% endblock %}

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -28,9 +28,21 @@
       You won't receive a physical permit. Wardens will check your vehicle's registration number.
     </p>
     {% else %}
-    <p>
-      You can expect your permit to arrive within 5 working days.
-    </p>
+    <p>  
+{% if council.payOnline %}
+  <p>  
+    You can expect your permit to arrive within 5 working days.
+  </p>
+{% else %}
+  <p>
+    Once we have processed and approved your application, we will contact you for payment. You will be able to pay over the phone by either a debit/credit card (no service charges apply).
+  </p>
+  <p>
+    You can expect your permit to arrive within 5 working days of your payment.
+  </p>
+{% endif %}
+        
+    
     <p>
       We'll send your parking permit to this address:
     </p>


### PR DESCRIPTION
This adds an option in the council config to set online payment = true/false
Screenshots below show changes with payOnline=false

Offline payment copy based on that used for the current live Oxfordshire application process.

pre-payment before:
![pre-payment-before](https://cloud.githubusercontent.com/assets/2970019/24617203/39217882-188b-11e7-980c-8d1b54fccd49.png)
pre-payment after:
![pre-payment-after-offline](https://cloud.githubusercontent.com/assets/2970019/24617230/45278d74-188b-11e7-815e-d1a4a5f6f6f0.png)

success before:
![success-before](https://cloud.githubusercontent.com/assets/2970019/24617266/594eb962-188b-11e7-99c8-7fda4601410f.png)
success after:
![success-after-offline-pay](https://cloud.githubusercontent.com/assets/2970019/24617293/6aafd9e8-188b-11e7-8779-208b7dde3a4e.png)


