### PR TITLE
Choice of start date

### DIFF
--- a/app/councils.json
+++ b/app/councils.json
@@ -7,6 +7,7 @@
     "permitMax": 4,
     "permitsCosts": [51, 81, 153, 153],
     "payOnline":true,
+    "userChooseStartDate":true,
     "permitWait": 5,
     "tempPermit":true,
     "string": "argleton",
@@ -21,6 +22,7 @@
     "permitMax": 2,
     "permitsCosts": [52],
     "payOnline":true,
+    "userChooseStartDate":true,
     "permitWait": 0,
     "tempPermit":true,
     "string": "buckinghamshire"
@@ -33,6 +35,7 @@
     "limitByHousehold":true,
     "permitsCosts": [51,61,71,120],
     "payOnline":true,
+    "userChooseStartDate":true,
     "permitWait": 5,
     "tempPermit":true,
     "string" : "cambridgeshire"
@@ -45,6 +48,7 @@
     "permitMax": 2,
     "permitsCosts": [130,130,130,130],
     "payOnline":true,
+    "userChooseStartDate":true,
     "permitWait": 0,
     "tempPermit":true,
     "string" : "northumberland"
@@ -57,6 +61,7 @@
     "permitMax": 5,
     "permitsCosts": [0, 20, 40, 60],
     "payOnline":true,
+    "userChooseStartDate":true,
     "permitWait": 3,
     "tempPermit":true,
     "string" : "sunderland"
@@ -69,6 +74,7 @@
     "permitMax": 67,
     "permitsCosts": [67, 77, 100, 100],
     "payOnline":true,
+    "userChooseStartDate":true,
     "permitWait": 0,
     "tempPermit":true,
     "string" : "unbranded"

--- a/app/routes.js
+++ b/app/routes.js
@@ -26,6 +26,25 @@ router.get('*/example-service/*', function (req, res) {
   }
 });
 
+function niceDate(d) {
+  var monthNames = [
+     "January", "February", "March",
+     "April", "May", "June", "July",
+     "August", "September", "October",
+     "November", "December"
+   ];
+  var suffixes =
+  //    0     1     2     3     4     5     6     7     8     9
+     [ "th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th",
+  //    10    11    12    13    14    15    16    17    18    19
+       "th", "th", "th", "th", "th", "th", "th", "th", "th", "th",
+  //    20    21    22    23    24    25    26    27    28    29
+       "th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th",
+  //    30    31
+       "th", "st" ];    
+   return d.getDate()+suffixes[d.getDate()]+" "+monthNames[d.getMonth()]+" "+d.getFullYear();
+}
+
 // add your routes here
 
 router.get('/service-patterns/concessionary-travel/example-service/photo/photo-guide', function (req, res) {
@@ -50,6 +69,26 @@ router.get('/service-patterns/parking-permit/example-service/eligible', function
   } else {
     res.render('service-patterns/parking-permit/example-service/eligible')
   }
+})
+
+router.all('/service-patterns/parking-permit/example-service/pre-payment', function (req, res) {
+  var dateObj={};
+  var d = req.session.data;
+  if (d.permitStartChoice=="other") {
+    dateObj.startDate = new Date(d.permitChoiceYear+"-"+d.permitChoiceMonth+"-"+d.permitChoiceDay);    
+  } else {
+    dateObj.startDate = new Date();
+  }
+  dateObj.niceStartDate = niceDate(dateObj.startDate);
+  if (d.permitChoice=="12 month") {
+    dateObj.endDate=dateObj.startDate;
+    dateObj.endDate.setFullYear(dateObj.startDate.getFullYear()+1);
+  } else {
+    dateObj.endDate=dateObj.startDate;
+    dateObj.endDate.setMonth(dateObj.startDate.getMonth()+6);
+  }
+  dateObj.niceEndDate = niceDate(dateObj.endDate);
+  res.render('service-patterns/parking-permit/example-service/pre-payment',dateObj);
 })
 
 router.get('/service-patterns/concessionary-travel/example-service/confirm-address', function (req, res) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -74,10 +74,15 @@ router.get('/service-patterns/parking-permit/example-service/eligible', function
 router.all('/service-patterns/parking-permit/example-service/pre-payment', function (req, res) {
   var dateObj={};
   var d = req.session.data;
+  var earliestDate = new Date();
+  earliestDate.setDate(earliestDate.getDate()+d.council.permitWait);
   if (d.permitStartChoice=="other") {
-    dateObj.startDate = new Date(d.permitChoiceYear+"-"+d.permitChoiceMonth+"-"+d.permitChoiceDay);    
+    dateObj.startDate = new Date(d.permitChoiceYear+"-"+d.permitChoiceMonth+"-"+d.permitChoiceDay);  
+    if (dateObj.startDate < earliestDate) {
+      dateObj.startDate=earliestDate;
+    }  
   } else {
-    dateObj.startDate = new Date();
+    dateObj.startDate = earliestDate;
   }
   dateObj.niceStartDate = niceDate(dateObj.startDate);
   if (d.permitChoice=="12 month") {

--- a/app/views/service-patterns/parking-permit/example-service/permit-price.html
+++ b/app/views/service-patterns/parking-permit/example-service/permit-price.html
@@ -73,8 +73,21 @@
 {% set halfCost = 0 %}
 {% set fullCost = 0 %}
 {% endif %}
+{% if(council.permitsCosts[0] === 0) %}
+{% set freePermit = true %}
+{% endif %}
 
-<form action="permit-details" method="post">
+{% if council.userChooseStartDate %}
+{% set formTarget = "permit-details"  %}
+{% else %}
+{% if freePermit %}
+{% set formTarget = "contact-reference"  %}
+{% else %}
+{% set formTarget = "pre-payment"  %}
+{% endif %}
+{% endif %}
+
+<form action="{{formTarget}}" method="post">
   <div class="form-group">
     <fieldset>
 
@@ -92,11 +105,11 @@
     </fieldset>
   </div>
 
-
+{% if council.userChooseStartDate==true %}
   <p>
     You'll set the permit start date in the next step.
   </p>
-
+{% endif %}
   <input type="submit" class="button" value="Next" />
 
 </form>

--- a/app/views/service-patterns/parking-permit/example-service/pre-payment.html
+++ b/app/views/service-patterns/parking-permit/example-service/pre-payment.html
@@ -47,7 +47,7 @@
         Start date
       </th>
       <th>
-        14th March 2017
+        {{ niceStartDate }}
       </th>
     </tr>
     <tr>
@@ -55,7 +55,7 @@
         Expiry date
       </th>
       <th>
-        {{ '14th September 2017' if permitChoice == '6 month' else '14th March 2018' }}
+        {{ niceEndDate }}
       </th>
     </tr>
     <tr>

--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -73,7 +73,7 @@
         Your parking permit allows you to park in {{council.parkingBoundary}} at any time.
       </li>
       <li>
-        Your permit expires in 12 months. You've signed up to receive an email and text when your permit expires.
+        You've signed up to receive an email and text when your permit expires.
       </li>
     </ul>
 


### PR DESCRIPTION
This creates a configuration variable for each council to set whether they can allow users to determine permit start date or not ("userChooseStartDate":true / false)

If userChooseStartDate is false, the page to do this is skipped (routed to either contact-reference or pre-payment, depending on status of freePermit variable.

Also updated pre-payment.html to calculate permit start and end dates based on user input.

No screenshots included as no visible page to any pages.
 