### PR TITLE
Better content for explaining what people need to use Verify

### DIFF
--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -22,10 +22,7 @@
             Your permit will arrive within 5 working days
           </li>
           <li>
-            To sign up, you'll need to answer some identity questions
-          </li>
-          <li>
-            You'll also need an email address
+            To sign up, you'll need to prove your identity and have an email address
           </li>
         </ul>
       </div>

--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -22,7 +22,10 @@
             Your permit will arrive within 5 working days
           </li>
           <li>
-            To sign up, you'll need to answer identity questions online
+            To sign up, you'll need to answer some identity questions
+          </li>
+          <li>
+            You'll also need an email address
           </li>
         </ul>
       </div>
@@ -46,7 +49,7 @@
           Your permit will arrive within 10 working days
         </li>
         <li>
-          You'll need to upload and scan 2 documents
+          You'll need to upload a document to prove your address {{"and a document to prove your age" if serviceString == 'concessionary-travel' }}
         </li>
       </ul>
     </div>

--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -5,7 +5,7 @@
   </p>
 
   <form>
-    {% set formTitle = "How do you want to claim your resident's parking permit?" if serviceString == "parking-permit" else "How do you want to claim your older person's bus pass?" %}
+    {% set formTitle = "How do you want us to check your identity?" %}
 
     <h2 class="heading-medium">{{formTitle}}</h2>
     <legend class="visually-hidden">{{formTitle}}</legend>
@@ -13,7 +13,7 @@
     <div class="radio-with-bullets">
       <label class="block-label selection-button-radio" data-target="verify-consent" for="verify-option">
         <input id="verify-option" type="radio" name="radio-group" value="pre-verify">
-        <span class="heading-small">Sign in with GOV.UK Verify</span>
+        <span class="heading-small">Use GOV.UK Verify</span>
       </label>
 
       <div class="form-group verify">
@@ -22,7 +22,7 @@
             Your permit will arrive within 5 working days
           </li>
           <li>
-            To sign up, you'll need to prove your identity and have an email address
+            You'll need to answer some security questions if this is your first time using GOV.UK Verify
           </li>
         </ul>
       </div>
@@ -46,7 +46,7 @@
           Your permit will arrive within 10 working days
         </li>
         <li>
-          You'll need to upload a document to prove your address {{"and a document to prove your age" if serviceString == 'concessionary-travel' }}
+          You'll need to upload a recent utility bill {{"and your passport or driving license to prove your age" if serviceString == 'concessionary-travel' }}
         </li>
       </ul>
     </div>

--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -1,7 +1,7 @@
 
 <div class="column-two-thirds">
   <p>
-      We need to make sure that you are eligible for {{ 'a parking permit' if serviceString == 'parking-permit' else 'a bus pass' }}.
+      We need to make sure you're eligible for {{ 'a parking permit' if serviceString == 'parking-permit' else 'a bus pass' }}.
   </p>
 
   <form>

--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -46,7 +46,7 @@
           Your permit will arrive within 10 working days
         </li>
         <li>
-          You'll need to upload a recent utility bill {{"and your passport or driving license to prove your age" if serviceString == 'concessionary-travel' }}
+          You'll need to upload a recent utility bill {{"and your passport or driving licence to prove your age" if serviceString == 'concessionary-travel' }}
         </li>
       </ul>
     </div>

--- a/app/views/common-content/verify-reuse.html
+++ b/app/views/common-content/verify-reuse.html
@@ -7,7 +7,7 @@
 <ul class="list-bullet list">
   <li><a href="https://www.gov.uk/claim-redundancy">claim your redundancy payment and monies owed</a></li>
   <li><a href="https://www.gov.uk/check-state-pension">check your State Pension</a></li>
-  <li><a href="https://www.gov.uk/renew-medical-driving-licence">renew your short-term medical driving license</a></li>
+  <li><a href="https://www.gov.uk/renew-medical-driving-licence">renew your short-term medical driving licence</a></li>
   <li><a href="https://www.gov.uk/help-friends-family-tax">help friends and family with their tax</a></li>
   <li><a href="https://www.gov.uk/report-driving-medical-condition">report a medical condition that affects your driving</a></li>
   <li><a href="https://www.gov.uk/view-driving-licence">view or share your driving licence information</a></li>

--- a/app/views/service-patterns/concessionary-travel/example-service/add-poage.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/add-poage.html
@@ -9,7 +9,7 @@
 
   <p>This could be any one of the following documents</p>
   <ul class="list list-bullet">
-        <li> your driving license</li>
+        <li> your driving licence</li>
         <li> your passport </li>
         <li> a national identity card</li>
   </ul>

--- a/app/views/service-patterns/concessionary-travel/example-service/prove-identity.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/prove-identity.html
@@ -1,7 +1,7 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for an older person's bus pass" %}
-{% set pageTitle = "Verifying your identity" %}
+{% set pageTitle = "Checking your identity" %}
 
 {% block content %}
 

--- a/app/views/service-patterns/concessionary-travel/example-service/verification-failed.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/verification-failed.html
@@ -15,7 +15,7 @@
 
   <ul class="list list-bullet">
     <li>Proof of address, such as a council tax bill or a recent utility bill or a tennancy agreement or a mortgage statement</li>
-    <li>Proof of age, such as a birth certificate, a passport or a driving license</li>
+    <li>Proof of age, such as a birth certificate, a passport or a driving licence</li>
   </ul>
 
   <a class="button" href="add-poa" role="button">Continue</a>

--- a/app/views/service-patterns/parking-permit/example-service/prove-identity.html
+++ b/app/views/service-patterns/parking-permit/example-service/prove-identity.html
@@ -1,7 +1,7 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Claim your resident's parking permit" %}
+{% set pageTitle = "Checking your identity" %}
 
 {% block content %}
 


### PR DESCRIPTION
Documented in issue #338, it's clear people need to know that they need an email address to use Verify, and that they'll need a proof of address to use the alternative route. This newer content aims to clearly show that.

## Before

![screenshot-verify-local-patterns herokuapp com 2017-04-18 13-11-38](https://cloud.githubusercontent.com/assets/4106955/25130034/950a25f0-2438-11e7-90b4-b93c3476db99.png)

## After

![screenshot-localhost-3000 2017-04-18 13-12-02](https://cloud.githubusercontent.com/assets/4106955/25130048/a233e856-2438-11e7-8022-029a6438340b.png)
