### PR TITLE
Added copy to let users know they'll find out about different types of permit available

### DIFF
--- a/app/views/service-patterns/parking-permit/example-service/check-boundary.html
+++ b/app/views/service-patterns/parking-permit/example-service/check-boundary.html
@@ -8,10 +8,19 @@
 <div class="column-two-thirds">
 
   <p>
-    To check if you need a permit, enter the postcode of the area where you'd like to park.
+    Tell us the postcode for the area you want to park in, to find out:
+    <ul class="list list-bullet">
+      <li>
+        if you need a permit
+      </li>
+      <li>
+      types of permit available to you
+    </li>
+    </ul>
   </p>
-
-  <div class="postcode-search-form" data-module="track-submit" data-track-category="postcodeSearch:find_local_council" data-track-action="postcodeSearchStarted">
+  <br>
+</br>
+<div class="postcode-search-form" data-module="track-submit" data-track-category="postcodeSearch:find_local_council" data-track-action="postcodeSearchStarted">
 
     <form method="post" action="resident-choice" id="local-locator-form" class="find-location-for-service">
       <fieldset>

--- a/app/views/service-patterns/parking-permit/example-service/check-boundary.html
+++ b/app/views/service-patterns/parking-permit/example-service/check-boundary.html
@@ -9,23 +9,20 @@
 
   <p>
     Tell us the postcode for the area you want to park in, to find out:
-    <ul class="list list-bullet">
-      <li>
-        if you need a permit
-      </li>
-      <li>
+  </p>
+  <ul class="list list-bullet">
+    <li>
+      if you need a permit
+    </li>
+    <li>
       types of permit available to you
     </li>
-    </ul>
-  </p>
-  <br>
-</br>
-<div class="postcode-search-form" data-module="track-submit" data-track-category="postcodeSearch:find_local_council" data-track-action="postcodeSearchStarted">
+  </ul>
 
+  <div class="postcode-search-form" data-module="track-submit" data-track-category="postcodeSearch:find_local_council" data-track-action="postcodeSearchStarted">
     <form method="post" action="resident-choice" id="local-locator-form" class="find-location-for-service">
       <fieldset>
         <legend class="visuallyhidden">Postcode lookup</legend>
-
         <div class="ask_location">
           <label class="heading-small" for="postcode">Enter a postcode</label>
           <p>For example SW1A 2AA</p>
@@ -36,11 +33,8 @@
           </p>
         </div>
       </fieldset>
-
     </form>
   </div>
-
-
 
 </div>
 


### PR DESCRIPTION
As a solution to #294, added copy to let users know they'll be informed of different types of permit available to them when they've input their postcode.

Before
<img width="756" alt="screen shot 2017-05-08 at 15 26 22" src="https://cloud.githubusercontent.com/assets/27814324/25809664/a18a3892-3405-11e7-8e5d-271defa78421.png">

After
![screen shot 2017-05-08 at 15 36 22](https://cloud.githubusercontent.com/assets/27814324/25809678/a926fba8-3405-11e7-9218-39745b27571b.png)
