### PR TITLE
PR: Adding line of copy to Start to flag different types of permit

### DIFF
--- a/app/views/service-patterns/parking-permit/example-service/start-page.html
+++ b/app/views/service-patterns/parking-permit/example-service/start-page.html
@@ -8,10 +8,14 @@
 <div class="column-two-thirds">
 
   <p>
-    In some parts of {{council.shortName}}, you'll need a parking permit to park your car or other vehicle.
+    You may need a parking permit to park your car or vehicle in some areas of {{council.shortName}}.
   </p>
   <p>
-    Parking permits allow you to park within a given boundary, 24 hours a day and 7 days a week.
+    For example, a resident's parking permit, or a business and trade parking permit.
+  </p>
+  <p>
+  <p>
+    A permit allows you to park in a particular area, 24 hours a day, 7 days a week.
   </p>
 
 

--- a/app/views/service-patterns/parking-permit/example-service/start-page.html
+++ b/app/views/service-patterns/parking-permit/example-service/start-page.html
@@ -14,10 +14,8 @@
     For example, a resident's parking permit, or a business and trade parking permit.
   </p>
   <p>
-  <p>
     A permit allows you to park in a particular area, 24 hours a day, 7 days a week.
   </p>
-
 
   <a class="button button-start" href="check-boundary" role="button">Check if you need a permit</a>
 


### PR DESCRIPTION
Resolves #294

Adding line of copy to flag different types of permit users could be looking for from this page, so they know they’re in the right place for what they’re looking for. Editing related copy to be more concise and user-centric. 

Before
![screen shot 2017-05-09 at 14 09 01](https://cloud.githubusercontent.com/assets/27814324/25853466/c007dcf6-34c4-11e7-828e-f51013ebedb4.png)

After
![screen shot 2017-05-09 at 14 25 49](https://cloud.githubusercontent.com/assets/27814324/25853471/c538d176-34c4-11e7-8959-864e8a2af97d.png)

