### PR TITLE
PR: Adding Verify-dependant application details to Prove ID choice page

### DIFF
--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -23,13 +23,13 @@
               you'll need to answer some security questions
           </li>
           <li>
-              permits usually take <b class="font-strong"> {{council.permitWait}} working days </b> to arrive
-              {% if council.tempPermit == true %}
-              {% endif %}
+              permits usually take {{council.permitWait}} working days to arrive
           </li>
+          {% if council.tempPermit == true %}
           <li>
               you'll receive a temporary permit
           </li>
+          {% endif %}
           <li>
               creating an account takes about 15 minutes and the rest of the application is around 2 minutes
           </li>
@@ -56,9 +56,11 @@
           <li>
             permits usually take 10 working days to arrive
           </li>
+          {% if council.tempPermit == true %}
           <li>
             you won't receive a temporary permit
           </li>
+          {% endif %}
           <li>
             your application could take up to 20 minutes
           </li>

--- a/app/views/common-content/prove-identity.html
+++ b/app/views/common-content/prove-identity.html
@@ -13,18 +13,27 @@
     <div class="radio-with-bullets">
       <label class="block-label selection-button-radio" data-target="verify-consent" for="verify-option">
         <input id="verify-option" type="radio" name="radio-group" value="pre-verify">
-        <span class="heading-small">Use GOV.UK Verify</span>
+        <span class="heading-small">Use GOV.UK Verify, the new way to prove who you are online</span>
       </label>
 
       <div class="form-group verify">
-        <ul class="list">
+
+        <ul class="list list-bullet">
           <li>
-            Your permit will arrive within 5 working days
+              you'll need to answer some security questions
           </li>
           <li>
-            You'll need to answer some security questions if this is your first time using GOV.UK Verify
+              permits usually take <b class="font-strong"> {{council.permitWait}} working days </b> to arrive
+              {% if council.tempPermit == true %}
+              {% endif %}
           </li>
-        </ul>
+          <li>
+              you'll receive a temporary permit
+          </li>
+          <li>
+              creating an account takes about 15 minutes and the rest of the application is around 2 minutes
+          </li>
+          </ul>
       </div>
     </div>
 
@@ -41,14 +50,19 @@
     </label>
 
     <div class="form-group">
-      <ul class="list">
-        <li>
-          Your permit will arrive within 10 working days
-        </li>
-        <li>
-          You'll need to upload a recent utility bill {{"and your passport or driving licence to prove your age" if serviceString == 'concessionary-travel' }}
-        </li>
-      </ul>
+        <ul class="list list-bullet">
+          <li>you'll need to scan and upload a recent utility bill {{"and your passport or driving licence to prove your age" if serviceString == 'concessionary-travel' }}
+          </li>
+          <li>
+            permits usually take 10 working days to arrive
+          </li>
+          <li>
+            you won't receive a temporary permit
+          </li>
+          <li>
+            your application could take up to 20 minutes
+          </li>
+        </ul>
     </div>
 
   </div>

--- a/app/views/service-patterns/parking-permit/example-service/prove-identity.html
+++ b/app/views/service-patterns/parking-permit/example-service/prove-identity.html
@@ -4,41 +4,6 @@
 {% set pageTitle = "Checking your identity" %}
 
 {% block content %}
-<p>
-  You can apply for this service using <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">GOV.UK Verify</a> the new way to prove who you are online:
-</p>
-<p>
-  <ul class="list list-bullet">
-    <li>
-      creating an account takes about 15 minutes
-    </li>
-    <li>
-      the rest of the application takes around 2 minutes
-    </li>
-    <li>
-      permits usually take <b class="font-strong"> {{council.permitWait}} working days </b> to arrive
-      {% if council.tempPermit == true %}
-      {% endif %}
-    <li>
-      you'll get a temporary permit at the end of your online application
-    </ul>
-  </p>
-  <p>
-    Or apply without using Verify:
-    <ul class="list list-bullet">
-    <li>find, scan and upload documents – this could take up to 20 minutes
-    </li>
-    <li>
-      the rest of the application takes around 2 minutes
-    </li>
-    <li>
-      permits usually take 10 working days to arrive
-    </li>
-    <li>
-      you won't receive a temporary permit
-    </li>
-  </ul>
-</p>
 
   {% set serviceString = "parking-permit" %}
   {% include 'common-content/prove-identity.html' %}

--- a/app/views/service-patterns/parking-permit/example-service/prove-identity.html
+++ b/app/views/service-patterns/parking-permit/example-service/prove-identity.html
@@ -4,8 +4,44 @@
 {% set pageTitle = "Checking your identity" %}
 
 {% block content %}
+<p>
+  You can apply for this service using <a href="https://www.gov.uk/government/publications/introducing-govuk-verify/introducing-govuk-verify">GOV.UK Verify</a> the new way to prove who you are online:
+</p>
+<p>
+  <ul class="list list-bullet">
+    <li>
+      creating an account takes about 15 minutes
+    </li>
+    <li>
+      the rest of the application takes around 2 minutes
+    </li>
+    <li>
+      permits usually take <b class="font-strong"> {{council.permitWait}} working days </b> to arrive
+      {% if council.tempPermit == true %}
+      {% endif %}
+    <li>
+      you'll get a temporary permit at the end of your online application
+    </ul>
+  </p>
+  <p>
+    Or apply without using Verify:
+    <ul class="list list-bullet">
+    <li>find, scan and upload documents – this could take up to 20 minutes
+    </li>
+    <li>
+      the rest of the application takes around 2 minutes
+    </li>
+    <li>
+      permits usually take 10 working days to arrive
+    </li>
+    <li>
+      you won't receive a temporary permit
+    </li>
+  </ul>
+</p>
 
   {% set serviceString = "parking-permit" %}
   {% include 'common-content/prove-identity.html' %}
+
 
 {% endblock %}


### PR DESCRIPTION
Relates to issues #400 #401 #402 #477 plus user needs to a) know online application length and b) know permit wait length which I can't see tickets for but was asked to include at the front of the application.

Before
![screen shot 2017-05-11 at 10 31 09](https://cloud.githubusercontent.com/assets/27814324/25942543/0d6a74d8-3635-11e7-9b7d-58d5bb8c77ea.png)

After
![screen shot 2017-05-11 at 10 30 42](https://cloud.githubusercontent.com/assets/27814324/25942553/160f3218-3635-11e7-92dd-cdec10b23cf8.png)
