### PR TITLE
PR: Amending content About the service/application and copy this impacts on

### DIFF
--- a/app/views/service-patterns/concessionary-travel/example-service/start-page.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-page.html
@@ -8,22 +8,22 @@
   <div class="column-two-thirds">
     <p>
       You can get a bus pass for free travel when you reach the female State Pension age, whether you’re a man or a woman. <a href="https://www.gov.uk/state-pension-age/">Check your state pension age on GOV.UK.</a>
+    </p>
     <p>
       If you don't live in {{council.shortName}}, <a href="https://www.gov.uk/find-local-council">find your local council</a>.
-    </p>
     </p>
     <h3 class="heading-medium">Using your pass</h3>
     <p>
       Bring your bus pass whenever you travel by bus. It's valid:
+    </p>
     <ul class="list list-bullet">
       <li>on all local bus services in England</li>
       <li>9.30am to 11pm weekdays</li>
       <li>any time Saturdays, Sundays or bank holidays</li>
     </ul>
-    </p>
     <h3 class="heading-medium">About your application</h3>
-      <ol class="list list-number">
-        <li>Complete online security checks or scan documents to prove you’re eligible.</li>
+    <ol class="list list-number">
+      <li>Complete online security checks or scan documents to prove you’re eligible.</li>
       <li>Upload a digital photo – we'll give you guidance on doing this.</li>
       <li>Submit your application online.</li>
       <li>We'll send your bus pass to you by post.</li>

--- a/app/views/service-patterns/concessionary-travel/example-service/start-page.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-page.html
@@ -8,13 +8,26 @@
   <div class="column-two-thirds">
     <p>
       You can get a bus pass for free travel when you reach the female State Pension age, whether you’re a man or a woman. <a href="https://www.gov.uk/state-pension-age/">Check your state pension age on GOV.UK.</a>
-    </p>
     <p>
-      The pass is valid on all local bus services in England at any time on a Saturday, Sunday or bank holiday, and from 9.30am to 11pm on any other day.
+      If you don't live in {{council.shortName}}, <a href="https://www.gov.uk/find-local-council">find your local council</a>.
     </p>
+    </p>
+    <h3 class="heading-medium">Using your pass</h3>
     <p>
-      If you don't live in {{council.shortName}}, you need to <a href="https://www.gov.uk/find-local-council">find your local council</a>.
+      Bring your bus pass whenever you travel by bus. It's valid:
+    <ul class="list list-bullet">
+      <li>on all local bus services in England</li>
+      <li>9.30am to 11pm weekdays</li>
+      <li>any time Saturdays, Sundays or bank holidays</li>
+    </ul>
     </p>
+    <h3 class="heading-medium">About your application</h3>
+      <ol class="list list-number">
+        <li>Complete online security checks or scan documents to prove you’re eligible.</li>
+      <li>Upload a digital photo – we'll give you guidance on doing this.</li>
+      <li>Submit your application online.</li>
+      <li>We'll send your bus pass to you by post.</li>
+    </ol>
     <a class="button button-start" href="prove-identity" role="button">Apply for an older person's bus pass</a>
     <p>
       This service is for new applications. You can also:
@@ -27,24 +40,6 @@
         <a href="#">renew an expired bus pass.</a>
       </li>
     </ul>
-    <div class="panel panel-border-wide">
-      <h2 class="heading-small">About this service</h2>
-      <ol class="list list-number">
-        <li>
-          Identify yourself using GOV.UK Verify, or by scanning documents.
-        </li>
-        <li>
-          Upload a digital photo.
-        </li>
-        <li>
-          Submit your application, we'll send your bus pass by post.
-        </li>
-      </ol>
-    </div>
-
-    <p>
-      Remember to bring your bus pass whenever you use the bus.
-    </p>
 
     <p>
       If you need assistance using the online service, <a href="#">contact {{ council.name }}</a>.

--- a/lib/argleton_template.html
+++ b/lib/argleton_template.html
@@ -80,7 +80,7 @@
     <main id="content" role="main">
 
       {% if startPage %}
-      <h1 class="heading-xlarge">{{pageTitle}} in {{council.shortName}}</h1>
+      <h1 class="heading-xlarge">{{pageTitle}}</h1>
       {% else %}
       {% include "includes/service_breadcrumbs.html" %}
       <h1 class="heading-xlarge">{{pageTitle}}</h1>


### PR DESCRIPTION
Relates to #458 

@irinapencheva @sanjaypoyzer content fixes discussed in 458 and further content refinement in situ. 

2 things to note:

1. When there's a widget instead of the female pension age content, copy on the page will be less dense – but there will be more for the user to 'do'.
2. I'd like to take "in Argleton" off the h1 page title as they are 
a) on the Argleton Council website and 
b) there's a signposting copy line saying "If you don't live in Argleton find your local council".

Before
![screen shot 2017-05-12 at 14 29 16](https://cloud.githubusercontent.com/assets/27814324/26000079/6b554db2-371f-11e7-9c96-ca5e4e27d84a.png)

After
![screen shot 2017-05-12 at 12 49 18](https://cloud.githubusercontent.com/assets/27814324/25996906/7b8d7c76-3711-11e7-924c-95082b1ef408.png)