### PR TITLE
PR: Adding and making clearer copy on how to use your bus pass

### DIFF
--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -47,8 +47,6 @@
         9:30am to 11pm weekdays</li>
       <li>
         anytime Saturdays, Sundays and bank holidays
-      <li>
-        for Argleton residents only</li>
       </ul>
       <p>
         Using your pass:

--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -17,12 +17,12 @@
       You'll receive a confirmation email and text with this reference number.
     </p>
     <p>
-      You'll also receive another message within 3 days when your bus pass is on it's away.
+      You'll also receive another message within 3 days when your bus pass is on its way.
     </p>
 
   <!-- <p><a href="#">Request a confirmation email.</a></p> -->
     <p>
-     {% if skip_verify == true %} As long as your photo, proof of address and proof of age pass our manual checks, we'll send you your bus pass within 10 days. {% else %} As long as your photo passes our manual checks, we'll send you your bus pass within 5 days.{% endif %}
+     {% if skip_verify == true %} If your photo, proof of address and proof of age pass our manual checks, we'll send you your bus pass within 10 days. {% else %} If your photo passes our manual checks, we'll send you your bus pass within 5 days.{% endif %} If it doesn't pass we'll contact you.
     </p>
     <p>
       We'll send your bus pass to this address:
@@ -37,26 +37,39 @@
       <a href="#">Provide a different address</a>
     </div>
 
-    <h2 class="heading-medium">About your older person's bus pass</h2>
-
+    <h2 class="heading-medium">How to use your older person's bus pass</h2>
+    <p>
+        The pass is valid:
     <ul class="list list-bullet">
       <li>
-        When travelling, you must have your pass with you and present it to the driver to get your free travel.
+        on all local bus services in England</li>
+      <li>
+        9:30am to 11pm weekdays</li>
+      <li>
+        anytime Saturdays, Sundays and bank holidays
+      <li>
+        for Argleton residents only</li>
+      </ul>
+      <p>
+        Using your pass:
+    <ul class="list list-bullet">
+      <li>
+        bring your bus pass when you travel by bus and show the driver
       </li>
       <li>
-        You must not share your pass with anyone else.
+        don't share your pass with anyone
       </li>
       <li>
-        You are not permitted to hold more than one pass.
+        don't keep more than one pass at a time
       </li>
       <li>
-        Your pass will expire in 5 years. You've signed up to receive a text and email when it's time to renew your pass.
+        renew your pass when it expires in 5 years – you've signed up to receive a text and email when it's time to renew your pass
         <!-- <a href="/service-patterns/concessionary-travel/example-service/renewal-notification">sign up for a renewal notification</a>. -->
       </li>
-    </ul>
-
+      </ul>
     {% include "common-content/verify-reuse.html" %}
 
+</p>
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Pull request actioning discussion of solution to #472 "At the end of the transaction, users still wanted to know more about exactly when and where they could use their passes but couldn't"

Before
![screen shot 2017-05-12 at 15 04 21](https://cloud.githubusercontent.com/assets/27814324/26001442/4f65f714-3724-11e7-9591-63bc2b5f7ff0.png)

After
![screen shot 2017-05-12 at 13 37 50](https://cloud.githubusercontent.com/assets/27814324/25998295/402427be-3718-11e7-8db2-faae16a49bdd.png)

