### PR TITLE
PR: Content redesign on success page About your permit section

### DIFF
--- a/app/views/service-patterns/parking-permit/example-service/success.html
+++ b/app/views/service-patterns/parking-permit/example-service/success.html
@@ -55,25 +55,25 @@
     </div>
     {% if council.tempPermit == true %}
     <p>
-      In the mean time, you can print this <a href="#">temporary permit</a> and display it in your car window.
+      Until it arrives, you can print this <a href="#">temporary permit</a> and display it in your car window.
     </p>
     {% endif %}
 
     {% endif %}
 
-    <h2 class="heading-medium">About your parking permit</h2>
+    <h2 class="heading-medium">Using your permit</h2>
 
-    <ul class="list list-bullet">
+    <ol class="list list-number">
       <li>
-        You must display your permit clearly in your front car window when parking in {{council.parkingBoundary}}. Otherwise you may get a fine.
+        Display your {{ permitLength if council.sixmonth else "1 year" }} permit clearly in your car's front window when you park in {{council.parkingBoundary}} to avoid a fine.
       </li>
       <li>
-        Your parking permit allows you to park in {{council.parkingBoundary}} at any time.
+        Park at any time in {{council.parkingBoundary}}  with your permit displayed.
       </li>
       <li>
-        Your permit expires in {{ permitLength if council.sixmonth else "1 year" }}. You've signed up to receive an email and text when your permit expires.
+        Renew your permit when it expires in {{ permitLength if council.sixmonth else "1 year" }} – you've signed up to receive a reminder email and text.
       </li>
-    </ul>
+    </ol>
 
     {% include "common-content/verify-reuse.html" %}
 


### PR DESCRIPTION
From issue #456 generated by @lizziebruce content design review. 

See About your permit/Using your permit section below.

Note: the 6 months 12 months if else rule doesn't seem to be functioning.

Before
<img width="528" alt="screen shot 2017-05-19 at 17 14 57" src="https://cloud.githubusercontent.com/assets/27814324/26257133/584b6308-3cb7-11e7-84cc-38af08809da8.png">

After
<img width="510" alt="screen shot 2017-05-19 at 17 14 40" src="https://cloud.githubusercontent.com/assets/27814324/26257140/60af5bd0-3cb7-11e7-85ef-c3dfceaf0c0c.png">

