### PR TITLE
PR: Reducing Verify reuse links on CT success page

### DIFF
--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -68,7 +68,7 @@
   <h2 class="heading-medium">About your GOV.UK Verify account</h2>
 
     <p>
-      You can also reuse your GOV.UK Verify account on other government services such as:
+      You can reuse your GOV.UK Verify account for other government services  including:
 
       <ul class="list-bullet list">
     <li><a href="https://www.gov.uk/report-driving-medical-condition">report a medical condition that affects your driving</a></li>

--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -65,7 +65,16 @@
         <!-- <a href="/service-patterns/concessionary-travel/example-service/renewal-notification">sign up for a renewal notification</a>. -->
       </li>
       </ul>
-    {% include "common-content/verify-reuse.html" %}
+  <h2 class="heading-medium">About your GOV.UK Verify account</h2>
+
+    <p>
+      You can also reuse your GOV.UK Verify account on other government services such as:
+
+      <ul class="list-bullet list">
+    <li><a href="https://www.gov.uk/report-driving-medical-condition">report a medical condition that affects your driving</a></li>
+    <li><a href="https://www.universal-credit.service.gov.uk/sign-in">complete your claim or access your Universal Credit account</a></li>
+    <li><a href="https://www.gov.uk/log-in-file-self-assessment-tax-return/if-youre-already-registered">complete your Self Assessment</a></li></li>
+  </ul>
 
 </p>
     </div>

--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -65,10 +65,10 @@
         <!-- <a href="/service-patterns/concessionary-travel/example-service/renewal-notification">sign up for a renewal notification</a>. -->
       </li>
       </ul>
-  <h2 class="heading-medium">About your GOV.UK Verify account</h2>
+  <h2 class="heading-medium">Using your GOV.UK Verify account</h2>
 
     <p>
-      You can reuse your GOV.UK Verify account for other government services  including:
+      You can use your GOV.UK Verify account for other government services  including:
 
       <ul class="list-bullet list">
     <li><a href="https://www.gov.uk/report-driving-medical-condition">report a medical condition that affects your driving</a></li>


### PR DESCRIPTION
Reducing the amount of Verify reuse links should encourage users to read them, as less "blocky" text is more engaging

Before
![screen shot 2017-05-22 at 13 15 03](https://cloud.githubusercontent.com/assets/27814324/26308348/c330312c-3ef0-11e7-911c-567c1c8661f0.png)

After
![screen shot 2017-05-22 at 13 14 21](https://cloud.githubusercontent.com/assets/27814324/26308350/c5925828-3ef0-11e7-92d4-11efde80a3f4.png)

