### PR TITLE
PR: Changing sub-header on CT start page

### DIFF
--- a/app/views/service-patterns/concessionary-travel/example-service/start-page.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-page.html
@@ -21,7 +21,7 @@
       <li>9.30am to 11pm weekdays</li>
       <li>any time Saturdays, Sundays or bank holidays</li>
     </ul>
-    <h3 class="heading-medium">About your application</h3>
+    <h3 class="heading-medium">How to apply</h3>
     <ol class="list list-number">
       <li>Complete online security checks or scan documents to prove you’re eligible.</li>
       <li>Upload a digital photo – we'll give you guidance on doing this.</li>


### PR DESCRIPTION
Following UR on #458 making sub-header instructional/task-orientated to encourage users to read section.

Before 
![screen shot 2017-05-22 at 15 49 39](https://cloud.githubusercontent.com/assets/27814324/26314687/abb584dc-3f06-11e7-8f6b-33878e85accd.png)

After
![screen shot 2017-05-22 at 15 49 23](https://cloud.githubusercontent.com/assets/27814324/26314701/b24b466a-3f06-11e7-9189-719f77666391.png)


