### PR TITLE
PR: reducing and merging content start non Verify page / add POA page

### DIFF
--- a/app/views/service-patterns/parking-permit/example-service/start-non-verify.html
+++ b/app/views/service-patterns/parking-permit/example-service/start-non-verify.html
@@ -1,31 +1,42 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Apply for a resident's parking permit with document upload" %}
+{% set pageTitle = "Upload a proof of address" %}
 
 {% block content %}
 
 <div class="column-two-thirds">
 
   <p>
-   You can still apply online for a parking permit, but you'll need to scan and upload some documents.
+   Scan and upload a proof of address document, to help us identify you.
   </p>
-
-  <h2 class="heading-medium">To apply online you will need to provide:
-
-</h2>
-
+  <h2 class="heading-medium">Types of document</h2>
+  <p>
+  Your proof of address must include your name and current address.
+  <p>
+  </p>
+  It can be a:
+  </p>
   <ul class="list list-bullet">
       <li>
-      Proof of address, such as a council tax bill or a recent utility bill or a tenancy agreement or a mortgage statement
+      council tax bill – from last 3 months
+      </li>
+      <li>
+      utility bill – from last 3 months
+      </li>
+      <li>
+      tenancy agreement
+      </li>
+      <li>
+      mortgage statement
       </li>
   </ul>
+<br>
+</br>
+    {% include 'common-content/address-upload.html' %}
   <p>
-    You'll need to scan in and upload these documents, and we'll check them after your application.
+    We'll check your document when we receive your application.
   </p>
-
-  <a class="button button-start" href="add-poa" role="button">Apply online now</a>
-
 </main>
 
 {% endblock %}


### PR DESCRIPTION
This is part of #456 various content changes for smoother user journey

I'm suggesting reducing and merging content from Start non Verify page and Add proof of address page, particularly as the Verify choice page now already preps users they'll need to do some scanning and uploading.

Before Start non Verify
<img width="702" alt="screen shot 2017-05-24 at 13 05 04" src="https://cloud.githubusercontent.com/assets/27814324/26402435/4150d952-4082-11e7-8cdc-d44e91f126b6.png">


Before Add proof of address
<img width="730" alt="screen shot 2017-05-24 at 13 05 11" src="https://cloud.githubusercontent.com/assets/27814324/26402426/33863736-4082-11e7-90fc-6d9812f9eb62.png">

After merged
<img width="780" alt="screen shot 2017-05-24 at 13 04 50" src="https://cloud.githubusercontent.com/assets/27814324/26402438/48cef83a-4082-11e7-8979-22a4ddbde80c.png">

