### PR TITLE
PR: content fix for renewal notification page

### DIFF
--- a/app/views/common-content/contact-notifications.html
+++ b/app/views/common-content/contact-notifications.html
@@ -1,12 +1,12 @@
 <div class="column-two-thirds">
 
   <p>
-    We can send you a reminder in {% if item == 'resident\'s parking permit'%}{{ permitLength if council.sixmonth else "1 year" }}{% else %}5 years{% endif %} to renew your {{item}}.
+    We can send you a renewal reminder 30 days before your parking permit expires.
   </p>
 
   <p>
     <strong class="bold-medium">
-    How do you want to receive your renewal notification?
+    How do you want to receive your renewal reminder?
     </strong>
   </p>
 
@@ -15,7 +15,7 @@
       <fieldset>
 
         <legend class="visually-hidden">
-          How do you want to receive your renewal notification?
+          How do you want to receive your renewal reminder?
         </legend>
 
         <label class="block-label selection-button-checkbox" data-target="contact-by-email-input" for="contact-by-email">
@@ -34,6 +34,15 @@
         <div class="panel panel-border-narrow js-hidden" id="contact-by-text-input">
           <label class="form-label" for="contact-text-message">Mobile phone number</label>
           <input class="form-control" name="contactText" type="text" id="contact-text-message" value="{{contactText}}">
+        </div>
+
+        <label class="block-label selection-button-checkbox" data-target="contact-by-post-input" for="contact-by-post">
+          <input id="contact-by-post" type="checkbox" name="checkbox-contact-group" value="No">
+          By post
+        </label>
+        <div class="panel panel-border-narrow js-hidden" id="contact-by-post-input">
+          <label class="form-label" for="contact-address">Address</label>
+          <input class="form-control" name="contactPost" type="post" id="contact-post" value="{{contactPost}}">
         </div>
 
       </fieldset>

--- a/app/views/service-patterns/parking-permit/example-service/contact-notifications.html
+++ b/app/views/service-patterns/parking-permit/example-service/contact-notifications.html
@@ -1,7 +1,7 @@
 {% extends "layout_picker.html" %}
 
 {% set serviceName = "Apply for a resident's parking permit" %}
-{% set pageTitle = "Renewal notification" %}
+{% set pageTitle = "Renewal reminder" %}
 
 {% block content %}
 


### PR DESCRIPTION
Content fix for #450 and #325

Before
![screen shot 2017-06-01 at 15 06 48](https://cloud.githubusercontent.com/assets/27814324/26683565/2f1c493c-46dc-11e7-8298-d0159269eda8.png)

After
![screen shot 2017-06-01 at 15 06 00](https://cloud.githubusercontent.com/assets/27814324/26683583/3b22cba2-46dc-11e7-94bc-8705653e9fee.png)

After (By post open) 
![screen shot 2017-06-01 at 15 06 37](https://cloud.githubusercontent.com/assets/27814324/26683596/4525a8c2-46dc-11e7-84c9-3c01a6427d98.png)
NB 1. field not right for address input. 2. can we use address they supply for sending a physical permit to? 
