### PR TITLE
PR: Information on local bus services and additional area-specific discounts

### DIFF
--- a/app/views/service-patterns/concessionary-travel/example-service/start-page.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/start-page.html
@@ -25,6 +25,32 @@
       <li>9.30am to 11pm weekdays</li>
       <li>any time Saturdays, Sundays or bank holidays</li>
     </ul>
+    <details>
+      <summary><span class="summary">Find out about local bus services in England </span></summary>
+      <div class="panel panel-border-narrow">
+        <p>
+          The pass can be used on many bus services throughout England, as part of the English national concessionary travel scheme (ENCTS).
+          Local buses may include some tour buses and long-distance coach services that are registered as local bus services.
+        </p>
+        <p>
+          They don’t usually include sightseeing tours, other tourist related services, or services where the fare includes payment for another service, for example car parking in the case of Park-and-Ride.
+        </p>
+        <p>
+          National coach services are not generally included. National Express offers <a href="http://www.nationalexpress.com/waystosave/senior-coachcard.aspx">a fare reduction card</a> to people over 60. This is different from the older person's bus pass.
+        </p>
+        <p>
+          Check with the bus operator if in doubt.
+        </p>
+      </div>
+    </details>
+    <details>
+      <summary><span class="summary">Additional discounted travel in {{council.shortName}} for pass holders</span></summary>
+      <div class="panel panel-border-narrow">
+        <p>
+          Free text area for council-specific older person's bus pass-related travel concessions in the local area.
+        </p>
+      </div>
+    </details>
     <h3 class="heading-medium">How to apply</h3>
     <ol class="list list-number">
       <li>Complete online security checks or scan documents to prove you’re eligible.</li>

--- a/app/views/service-patterns/concessionary-travel/example-service/success.html
+++ b/app/views/service-patterns/concessionary-travel/example-service/success.html
@@ -41,9 +41,8 @@
       <a href="new-postal-address">Provide a different address</a>
     </div>
 
-    <h2 class="heading-medium">How to use your older person's bus pass</h2>
-    <p>
-        The pass is valid:
+    <h2 class="heading-medium">Where and when your pass is valid</h2>
+
     <ul class="list list-bullet">
       <li>
         on all local bus services in England</li>
@@ -52,8 +51,33 @@
       <li>
         anytime Saturdays, Sundays and bank holidays
       </ul>
-      <p>
-        Using your pass:
+			<details>
+	      <summary><span class="summary">Find out about local bus services in England </span></summary>
+	      <div class="panel panel-border-narrow">
+	        <p>
+	          The pass can be used on many bus services throughout England, as part of the English national concessionary travel scheme (ENCTS).
+	          Local buses may include some tour buses and long-distance coach services that are registered as local bus services.
+	        </p>
+	        <p>
+	          They don’t usually include sightseeing tours, other tourist related services, or services where the fare includes payment for another service, for example car parking in the case of Park-and-Ride.
+	        </p>
+	        <p>
+	          National coach services are not generally included. National Express offers <a href="http://www.nationalexpress.com/waystosave/senior-coachcard.aspx">a fare reduction card</a> to people over 60. This is different from the older person's bus pass.
+	        </p>
+	        <p>
+	          Check with the bus operator if in doubt.
+	        </p>
+	      </div>
+	    </details>
+	    <details>
+	      <summary><span class="summary">Additional discounted travel in {{council.shortName}} for pass holders</span></summary>
+	      <div class="panel panel-border-narrow">
+	        <p>
+	          Free text area for council-specific older person's bus pass-related travel concessions in the local area.
+	        </p>
+	      </div>
+	    </details>
+      <h2 class="heading-medium">Using your pass</h2>
     <ul class="list list-bullet">
       <li>
         bring your bus pass when you travel by bus and show the driver


### PR DESCRIPTION
Content fix for #580 

**Start page**
Before:
<img width="538" alt="screen shot 2017-06-29 at 12 55 08" src="https://user-images.githubusercontent.com/27814324/27686336-3f0d0418-5cca-11e7-973c-6899525c6760.png">

After:
<img width="539" alt="screen shot 2017-06-29 at 12 57 19" src="https://user-images.githubusercontent.com/27814324/27686416-91fd8ddc-5cca-11e7-8381-ceda8889a02b.png">

Expandable text expanded
<img width="598" alt="screen shot 2017-06-29 at 12 51 23" src="https://user-images.githubusercontent.com/27814324/27686353-4ee0eaee-5cca-11e7-83ae-207bfb24bb5b.png">

Not sure if we need to mention the National Express card ^^, may just confuse users and isn't a public service. Could just say "National coach services are not generally included."

Will be adding the expandable links to the Application complete page too.